### PR TITLE
[FEATURE] URL 언체이닝 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,12 @@ linclean-fastapi/
 │   │   └── analysis.py               # NormalizeResult 등 파이프라인 단계별 DTO
 │   │
 │   └── services/                     # 도메인/비즈니스 로직 (파이프라인 단계별 모듈)
-│       └── normalizer/               # 1단계: URL 정규화(Canonicalization)
-│           ├── __init__.py            # 진입점 (normalize_url re-export)
-│           └── normalize.py           # 입력 검증, 스킴·호스트 정규화, 포트·프래그먼트 제거, 퍼센트 인코딩 정돈, 경로 정규화, IDN 디코딩
+│       ├── normalizer/               # 1단계: URL 정규화(Canonicalization)
+│       │   ├── __init__.py            # 진입점 (normalize_url re-export)
+│       │   └── normalize.py           # 입력 검증, 스킴·호스트 정규화, 포트·프래그먼트 제거, 퍼센트 인코딩 정돈, 경로 정규화, IDN 디코딩
+│       └── unchainer/                # 1-2단계: URL 언체이닝(리다이렉트 추적)
+│           ├── __init__.py            # 진입점 (unchain_url re-export)
+│           └── unchain.py             # HEAD+GET 폴백, 체인 총 timeout, 스킴 방어, 의심 신호 수집
 │
 ├── alembic/                          # 외부 피드 캐시 스키마 마이그레이션
 │   ├── env.py                        # SQLite + batch mode 설정
@@ -76,10 +79,14 @@ linclean-fastapi/
 │
 ├── tests/                            # pytest 테스트
 │   ├── conftest.py                   # 공용 픽스처
-│   ├── demo_normalize.py            # URL 정규화 데모 스크립트
+│   ├── demo/                         # 데모 스크립트
+│   │   ├── demo_normalize.py         # URL 정규화 데모
+│   │   └── demo_unchain.py           # URL 언체이닝 데모
 │   └── services/
-│       └── normalizer/
-│           └── test_normalize.py     # URL 정규화 단위 테스트 (38개)
+│       ├── normalizer/
+│       │   └── test_normalize.py     # URL 정규화 단위 테스트 (38개)
+│       └── unchainer/
+│           └── test_unchain.py       # URL 언체이닝 단위 테스트 (23개)
 │
 ├── docs/                             # 기획서 등 설계 문서
 │   └── LinClean_기능_초안.pdf
@@ -115,6 +122,12 @@ linclean-fastapi/
   - **`normalizer/`** — 1단계. `normalize_url()` 로 URL 을 canonical form 으로
     정규화합니다 (스킴·호스트 소문자화, 기본 포트 제거, 퍼센트 인코딩 정돈,
     경로 dot-segment 해소, IDN 디코딩, 프래그먼트 제거, 입력 검증).
+  - **`unchainer/`** — 1-2단계. `unchain_url()` 로 리다이렉트 체인(3xx Location)
+    을 끝까지 추적해 최종 URL 을 확정합니다. HEAD 우선 → GET 폴백 전략으로
+    대역폭을 절약하면서 호환성을 확보하고, 네트워크 에러 시에도 GET 으로
+    재시도합니다. 체인 전체에 총 timeout 을 적용해 악의적 서버 방어가 가능하며,
+    `javascript:` / `data:` 같은 비허용 스킴 리다이렉트를 차단합니다.
+    스킴 다운그레이드·크로스 오리진 등의 의심 신호도 수집합니다.
 - **`middleware/`** — `RequestContextMiddleware` 가 매 요청마다 `X-Request-ID`
   를 생성/전파하고 structlog contextvars 에 바인딩합니다. 응답 헤더로도 echo
   되며 모든 로그 라인에 자동으로 따라붙습니다.
@@ -158,9 +171,13 @@ Spring `/internal/analysis-result` 콜백 POST
 - **정규화**: 스킴·호스트 소문자화, 기본 포트(`:80` / `:443`) 제거,
   프래그먼트(`#...`) 제거, 퍼센트 인코딩 정돈, 추적 파라미터(`utm_*` 등)
   정책적 제거, IDN(퓨니코드) → 유니코드 정규화
-- **언체이닝**: `HEAD` 요청만으로 리다이렉트 체인(3xx Location) 을 끝까지
-  따라가 **최종 분석 대상 URL** 을 확정합니다. 무한 루프 방지를 위해 방문한
-  URL 을 추적하며, hop 수가 5 이상이면 자체적으로 의심 신호로 가산합니다.
+- **언체이닝**: `HEAD` 우선 → `GET` 폴백 전략으로 리다이렉트 체인(3xx Location)
+  을 끝까지 따라가 **최종 분석 대상 URL** 을 확정합니다.
+  - 네트워크 에러(타임아웃·연결 실패 등) 발생 시에도 GET 으로 재시도
+  - 체인 전체에 총 timeout(기본 30초) 적용 — 악의적 서버의 지연 공격 방어
+  - `javascript:`, `data:` 등 비허용 스킴 리다이렉트 차단
+  - 스킴 다운그레이드(HTTPS→HTTP), 크로스 오리진, 무한 루프, max hop 초과 감지
+  - 각 hop 의 원본 Location 값(`raw_location`)과 절대경로 해석 결과를 모두 기록
 - 이후 2~4 단계는 모두 이 **최종 URL** 을 기준으로 동작합니다.
 
 ### 2단계 — 외부 위협 DB 대조

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -77,6 +77,16 @@ class Settings(BaseSettings):
     # 정규화
     normalizer_max_url_length: int = 1024
 
+    # 언체이닝
+    unchain_max_hops: int = 20
+    unchain_timeout_seconds: float = 10.0
+    unchain_per_hop_timeout_seconds: float = 5.0
+    unchain_user_agent: str = (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/131.0.0.0 Safari/537.36"
+    )
+
     # 점수 산정
     score_weight_gsb: int = 50
     score_weight_urlhaus: int = 50

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -79,8 +79,9 @@ class Settings(BaseSettings):
 
     # 언체이닝
     unchain_max_hops: int = 20
-    unchain_timeout_seconds: float = 10.0
-    unchain_per_hop_timeout_seconds: float = 5.0
+    unchain_timeout_seconds: float = 5.0
+    unchain_connect_timeout_seconds: float = 3.0
+    unchain_chain_timeout_seconds: float = 20.0
     unchain_user_agent: str = (
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
         "AppleWebKit/537.36 (KHTML, like Gecko) "

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -78,7 +78,7 @@ class Settings(BaseSettings):
     normalizer_max_url_length: int = 1024
 
     # 언체이닝
-    unchain_max_hops: int = 20
+    unchain_max_hops: int = 5
     unchain_timeout_seconds: float = 5.0
     unchain_connect_timeout_seconds: float = 3.0
     unchain_chain_timeout_seconds: float = 20.0

--- a/app/schemas/analysis.py
+++ b/app/schemas/analysis.py
@@ -13,7 +13,8 @@ class HopRecord(BaseModel):
 
     url: str = Field(description="이 hop에서 요청한 URL")
     status_code: int = Field(description="HTTP 응답 상태 코드")
-    location: str | None = Field(default=None, description="Location 헤더 값(있을 경우)")
+    raw_location: str | None = Field(default=None, description="Location 헤더 원본 값(상대경로 포함)")
+    location: str | None = Field(default=None, description="절대경로로 해석된 Location 값")
     method: str = Field(default="HEAD", description="요청에 사용한 HTTP 메서드")
 
 

--- a/app/schemas/analysis.py
+++ b/app/schemas/analysis.py
@@ -6,3 +6,27 @@ class NormalizeResult(BaseModel):
 
     original_url: str = Field(description="Original URL after trimming")
     normalized_url: str = Field(description="Canonicalized URL")
+
+
+class HopRecord(BaseModel):
+    """리다이렉트 체인의 개별 hop."""
+
+    url: str = Field(description="이 hop에서 요청한 URL")
+    status_code: int = Field(description="HTTP 응답 상태 코드")
+    location: str | None = Field(default=None, description="Location 헤더 값(있을 경우)")
+    method: str = Field(default="HEAD", description="요청에 사용한 HTTP 메서드")
+
+
+class UnchainResult(BaseModel):
+    """Stage 2 — URL 언체이닝(리다이렉트 추적) 결과."""
+
+    input_url: str = Field(description="언체이닝 시작 URL")
+    final_url: str = Field(description="최종 도달 URL")
+    hops: list[HopRecord] = Field(default_factory=list, description="리다이렉트 hop 기록")
+    hop_count: int = Field(default=0, description="총 hop 수")
+    timed_out: bool = Field(default=False, description="타임아웃 발생 여부")
+    error: str | None = Field(default=None, description="체인 중단 사유(에러 발생 시)")
+    signals: list[str] = Field(
+        default_factory=list,
+        description="탐지된 의심 신호 목록",
+    )

--- a/app/services/unchainer/__init__.py
+++ b/app/services/unchainer/__init__.py
@@ -1,0 +1,3 @@
+from app.services.unchainer.unchain import unchain_url
+
+__all__ = ["unchain_url"]

--- a/app/services/unchainer/unchain.py
+++ b/app/services/unchainer/unchain.py
@@ -6,8 +6,7 @@
 
 from __future__ import annotations
 
-import ssl
-from socket import gaierror
+import asyncio
 from urllib.parse import urljoin, urlparse
 
 import httpx
@@ -18,9 +17,31 @@ from app.schemas.analysis import HopRecord, UnchainResult
 # 리다이렉트로 간주할 상태 코드
 _REDIRECT_CODES: frozenset[int] = frozenset({301, 302, 303, 307, 308})
 
+# 리다이렉트 대상으로 허용하는 스킴 (javascript:, data: 등 차단)
+_ALLOWED_SCHEMES: frozenset[str] = frozenset({"http", "https"})
+
 
 async def unchain_url(url: str) -> UnchainResult:
     """리다이렉트 체인을 추적하고 최종 URL·hop 기록·의심 신호를 반환."""
+    try:
+        return await asyncio.wait_for(
+            _unchain_url_inner(url),
+            timeout=settings.unchain_chain_timeout_seconds,
+        )
+    except asyncio.TimeoutError:
+        return UnchainResult(
+            input_url=url,
+            final_url=url,
+            hops=[],
+            hop_count=0,
+            timed_out=True,
+            error="chain_timeout",
+            signals=[],
+        )
+
+
+async def _unchain_url_inner(url: str) -> UnchainResult:
+    """실제 체인 추적 로직. unchain_url에서 총 timeout으로 감싸서 호출."""
     hops: list[HopRecord] = []
     signals: list[str] = []
     visited: set[str] = set()
@@ -37,11 +58,10 @@ async def unchain_url(url: str) -> UnchainResult:
     async with httpx.AsyncClient(
         timeout=httpx.Timeout(
             settings.unchain_timeout_seconds,
-            connect=settings.unchain_per_hop_timeout_seconds,
+            connect=settings.unchain_connect_timeout_seconds,
         ),
         follow_redirects=False,
         verify=True,
-        # 쿠키·인증 비전송
         cookies=None,
     ) as client:
         for _ in range(settings.unchain_max_hops):
@@ -92,24 +112,25 @@ async def _follow_one_hop(
 ) -> tuple[HopRecord | None, str | None, str | None]:
     """단일 hop 요청. (hop_record, next_url_or_None, error_or_None) 반환.
 
-    HEAD 우선 → 실패 시 GET 폴백.
+    HEAD 우선 → 실패 시(상태 코드·네트워크 에러 모두) GET 폴백.
     """
     for method in ("HEAD", "GET"):
         try:
             resp = await client.request(method, url, headers=headers)
         except httpx.TimeoutException:
+            if method == "HEAD":
+                continue
             return None, None, "timeout"
-        except gaierror:
-            return None, None, "dns_failure"
-        except ssl.SSLError as e:
-            return None, None, f"tls_error: {e}"
         except httpx.ConnectError as e:
-            # DNS 실패가 ConnectError 안에 래핑되는 경우도 처리
+            if method == "HEAD":
+                continue
             cause = str(e).lower()
             if "name or service not known" in cause or "getaddrinfo" in cause:
                 return None, None, "dns_failure"
             return None, None, f"connection_refused: {e}"
         except httpx.HTTPError as e:
+            if method == "HEAD":
+                continue
             return None, None, f"http_error: {e}"
 
         # HEAD에서 405 등 클라이언트 에러면 GET 폴백
@@ -125,32 +146,45 @@ async def _follow_one_hop(
 
         # 리다이렉트 처리
         if resp.status_code in _REDIRECT_CODES:
-            location = resp.headers.get("location")
-            if not location:
+            raw_location = resp.headers.get("location")
+            if not raw_location:
                 hop = HopRecord(
                     url=url, status_code=resp.status_code, method=method,
                 )
                 return hop, None, "missing_location_header"
 
-            # 상대 경로 Location 해석
-            next_url = urljoin(url, location)
+            next_url = urljoin(url, raw_location)
+            parsed_next = urlparse(next_url)
+
+            # 허용되지 않는 스킴 방어 (javascript:, data: 등)
+            if parsed_next.scheme not in _ALLOWED_SCHEMES:
+                hop = HopRecord(
+                    url=url,
+                    status_code=resp.status_code,
+                    raw_location=raw_location,
+                    location=next_url,
+                    method=method,
+                )
+                signals.append(f"unsafe_scheme:{parsed_next.scheme}")
+                return hop, None, f"unsafe_redirect_scheme:{parsed_next.scheme}"
+
+            parsed_url = urlparse(url)
 
             hop = HopRecord(
                 url=url,
                 status_code=resp.status_code,
+                raw_location=raw_location,
                 location=next_url,
                 method=method,
             )
 
             # 스킴 다운그레이드 감지 (https → http)
-            if urlparse(url).scheme == "https" and urlparse(next_url).scheme == "http":
+            if parsed_url.scheme == "https" and parsed_next.scheme == "http":
                 signals.append("scheme_downgrade")
 
             # 크로스 오리진 호스트 변화
-            prev_host = urlparse(url).hostname
-            next_host = urlparse(next_url).hostname
-            if prev_host != next_host:
-                signals.append(f"cross_origin:{prev_host}->{next_host}")
+            if parsed_url.hostname != parsed_next.hostname:
+                signals.append(f"cross_origin:{parsed_url.hostname}->{parsed_next.hostname}")
 
             return hop, next_url, None
 

--- a/app/services/unchainer/unchain.py
+++ b/app/services/unchainer/unchain.py
@@ -7,6 +7,8 @@
 from __future__ import annotations
 
 import asyncio
+import ipaddress
+import socket
 from urllib.parse import urljoin, urlparse
 
 import httpx
@@ -19,6 +21,43 @@ _REDIRECT_CODES: frozenset[int] = frozenset({301, 302, 303, 307, 308})
 
 # 리다이렉트 대상으로 허용하는 스킴 (javascript:, data: 등 차단)
 _ALLOWED_SCHEMES: frozenset[str] = frozenset({"http", "https"})
+
+
+def _is_private_ip(ip_str: str) -> bool:
+    """외부 접근 불가(is_global=False)인 IP인지 확인.
+
+    is_reserved는 NAT64(64:ff9b::/96) 같은 공개 도달 가능 대역까지 잡아서
+    오탐이 발생하므로, is_global 기반으로 판단.
+    """
+    try:
+        addr = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return True  # 파싱 실패 시 안전하게 차단
+    return not addr.is_global
+
+
+async def _check_host_safety(url: str) -> str | None:
+    """호스트를 DNS 조회 후 내부 IP이면 에러 사유 반환, 안전하면 None."""
+    parsed = urlparse(url)
+    hostname = parsed.hostname
+    if not hostname:
+        return "invalid_host"
+
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    loop = asyncio.get_running_loop()
+
+    try:
+        addrinfo = await loop.getaddrinfo(
+            hostname, port, type=socket.SOCK_STREAM,
+        )
+    except socket.gaierror:
+        return "dns_failure"
+
+    for _, _, _, _, sockaddr in addrinfo:
+        if _is_private_ip(sockaddr[0]):
+            return "ssrf_blocked"
+
+    return None
 
 
 async def unchain_url(url: str) -> UnchainResult:
@@ -71,6 +110,14 @@ async def _unchain_url_inner(url: str) -> UnchainResult:
                 break
             visited.add(current_url)
 
+            # SSRF·DNS Rebinding 방어: 매 hop마다 목적지 IP 검증
+            safety_error = await _check_host_safety(current_url)
+            if safety_error is not None:
+                error = safety_error
+                if safety_error == "ssrf_blocked":
+                    signals.append("ssrf_blocked")
+                break
+
             hop, next_url, hop_error = await _follow_one_hop(
                 client, current_url, headers, signals,
             )
@@ -116,7 +163,10 @@ async def _follow_one_hop(
     """
     for method in ("HEAD", "GET"):
         try:
-            resp = await client.request(method, url, headers=headers)
+            # 헤더만 필요하므로 스트리밍으로 열고 본문은 즉시 닫음
+            req = client.build_request(method, url, headers=headers)
+            resp = await client.send(req, stream=True)
+            await resp.aclose()
         except httpx.TimeoutException:
             if method == "HEAD":
                 continue

--- a/app/services/unchainer/unchain.py
+++ b/app/services/unchainer/unchain.py
@@ -198,6 +198,9 @@ async def _follow_one_hop(
         if resp.status_code in _REDIRECT_CODES:
             raw_location = resp.headers.get("location")
             if not raw_location:
+                # 일부 서버는 HEAD 응답에서 Location을 생략하므로 GET으로 재시도
+                if method == "HEAD":
+                    continue
                 hop = HopRecord(
                     url=url, status_code=resp.status_code, method=method,
                 )

--- a/app/services/unchainer/unchain.py
+++ b/app/services/unchainer/unchain.py
@@ -1,0 +1,164 @@
+"""URL 언체이닝 — 파이프라인 2단계.
+
+정규화된 URL의 리다이렉트 체인을 끝까지 추적해서
+최종 목적지 URL과 경로상 의심 신호를 수집함.
+"""
+
+from __future__ import annotations
+
+import ssl
+from socket import gaierror
+from urllib.parse import urljoin, urlparse
+
+import httpx
+
+from app.core.config import settings
+from app.schemas.analysis import HopRecord, UnchainResult
+
+# 리다이렉트로 간주할 상태 코드
+_REDIRECT_CODES: frozenset[int] = frozenset({301, 302, 303, 307, 308})
+
+
+async def unchain_url(url: str) -> UnchainResult:
+    """리다이렉트 체인을 추적하고 최종 URL·hop 기록·의심 신호를 반환."""
+    hops: list[HopRecord] = []
+    signals: list[str] = []
+    visited: set[str] = set()
+    current_url = url
+    error: str | None = None
+    timed_out = False
+
+    headers = {
+        "User-Agent": settings.unchain_user_agent,
+        "Accept": "*/*",
+        "Accept-Language": "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7",
+    }
+
+    async with httpx.AsyncClient(
+        timeout=httpx.Timeout(
+            settings.unchain_timeout_seconds,
+            connect=settings.unchain_per_hop_timeout_seconds,
+        ),
+        follow_redirects=False,
+        verify=True,
+        # 쿠키·인증 비전송
+        cookies=None,
+    ) as client:
+        for _ in range(settings.unchain_max_hops):
+            # 무한 루프 감지
+            if current_url in visited:
+                signals.append("redirect_loop")
+                break
+            visited.add(current_url)
+
+            hop, next_url, hop_error = await _follow_one_hop(
+                client, current_url, headers, signals,
+            )
+
+            if hop is not None:
+                hops.append(hop)
+
+            if hop_error is not None:
+                error = hop_error
+                if hop_error == "timeout":
+                    timed_out = True
+                break
+
+            # 리다이렉트가 아니면 체인 종료
+            if next_url is None:
+                break
+
+            current_url = next_url
+        else:
+            # max_hops 도달
+            signals.append("max_hops_reached")
+
+    return UnchainResult(
+        input_url=url,
+        final_url=current_url,
+        hops=hops,
+        hop_count=len(hops),
+        timed_out=timed_out,
+        error=error,
+        signals=signals,
+    )
+
+
+async def _follow_one_hop(
+    client: httpx.AsyncClient,
+    url: str,
+    headers: dict[str, str],
+    signals: list[str],
+) -> tuple[HopRecord | None, str | None, str | None]:
+    """단일 hop 요청. (hop_record, next_url_or_None, error_or_None) 반환.
+
+    HEAD 우선 → 실패 시 GET 폴백.
+    """
+    for method in ("HEAD", "GET"):
+        try:
+            resp = await client.request(method, url, headers=headers)
+        except httpx.TimeoutException:
+            return None, None, "timeout"
+        except gaierror:
+            return None, None, "dns_failure"
+        except ssl.SSLError as e:
+            return None, None, f"tls_error: {e}"
+        except httpx.ConnectError as e:
+            # DNS 실패가 ConnectError 안에 래핑되는 경우도 처리
+            cause = str(e).lower()
+            if "name or service not known" in cause or "getaddrinfo" in cause:
+                return None, None, "dns_failure"
+            return None, None, f"connection_refused: {e}"
+        except httpx.HTTPError as e:
+            return None, None, f"http_error: {e}"
+
+        # HEAD에서 405 등 클라이언트 에러면 GET 폴백
+        if method == "HEAD" and resp.status_code in {405, 403, 400}:
+            continue
+
+        # 5xx 서버 에러 → 체인 중단
+        if resp.status_code >= 500:
+            hop = HopRecord(
+                url=url, status_code=resp.status_code, method=method,
+            )
+            return hop, None, f"server_error_{resp.status_code}"
+
+        # 리다이렉트 처리
+        if resp.status_code in _REDIRECT_CODES:
+            location = resp.headers.get("location")
+            if not location:
+                hop = HopRecord(
+                    url=url, status_code=resp.status_code, method=method,
+                )
+                return hop, None, "missing_location_header"
+
+            # 상대 경로 Location 해석
+            next_url = urljoin(url, location)
+
+            hop = HopRecord(
+                url=url,
+                status_code=resp.status_code,
+                location=next_url,
+                method=method,
+            )
+
+            # 스킴 다운그레이드 감지 (https → http)
+            if urlparse(url).scheme == "https" and urlparse(next_url).scheme == "http":
+                signals.append("scheme_downgrade")
+
+            # 크로스 오리진 호스트 변화
+            prev_host = urlparse(url).hostname
+            next_host = urlparse(next_url).hostname
+            if prev_host != next_host:
+                signals.append(f"cross_origin:{prev_host}->{next_host}")
+
+            return hop, next_url, None
+
+        # 리다이렉트 아닌 정상 응답 → 체인 종료
+        hop = HopRecord(
+            url=url, status_code=resp.status_code, method=method,
+        )
+        return hop, None, None
+
+    # 여기 도달 불가하지만 타입 안전
+    return None, None, "unexpected_fallthrough"  # pragma: no cover

--- a/tests/demo/demo_normalize.py
+++ b/tests/demo/demo_normalize.py
@@ -1,7 +1,7 @@
 """URL 정규화 데모.
 
 사용법:
-    python -m tests.demo_normalize
+    python -m tests.demo.demo_normalize
 """
 
 from __future__ import annotations

--- a/tests/demo/demo_unchain.py
+++ b/tests/demo/demo_unchain.py
@@ -1,7 +1,7 @@
 """URL 언체이닝 데모.
 
 사용법:
-    python -m tests.demo_unchain
+    python -m tests.demo.demo_unchain
 """
 
 from __future__ import annotations

--- a/tests/demo/demo_unchain.py
+++ b/tests/demo/demo_unchain.py
@@ -16,7 +16,7 @@ DIVIDER = "-" * 72
 CASES: list[tuple[str, str]] = [
     ("리다이렉트 없음", "https://www.google.com/"),
     ("HTTP → HTTPS 업그레이드", "http://google.com/"),
-    ("단축 URL (bit.ly 예시)", "https://bit.ly/3kF8Yv2"),
+    ("단축 URL (bit.ly 사용)", "https://bit.ly/4tGFJkf"),
     ("t.co 단축 URL", "https://t.co/example"),
     ("HTTP 301 리다이렉트", "http://github.com/"),
     ("상대 경로 리다이렉트", "https://httpbin.org/relative-redirect/2"),

--- a/tests/demo/demo_unchain.py
+++ b/tests/demo/demo_unchain.py
@@ -14,13 +14,20 @@ DIVIDER = "-" * 72
 
 # 실제 리다이렉트가 일어나는 공개 URL들 (데모 시점에 동작 보장 불가)
 CASES: list[tuple[str, str]] = [
-    ("리다이렉트 없음", "https://www.google.com/"),
-    ("HTTP → HTTPS 업그레이드", "http://google.com/"),
-    ("단축 URL (bit.ly 사용)", "https://bit.ly/4tGFJkf"),
-    ("t.co 단축 URL", "https://t.co/example"),
-    ("HTTP 301 리다이렉트", "http://github.com/"),
-    ("상대 경로 리다이렉트", "https://httpbin.org/relative-redirect/2"),
-    ("절대 경로 리다이렉트", "https://httpbin.org/absolute-redirect/3"),
+    # --- 기본 동작 ---
+    ("리다이렉트 없음 (200 OK)", "https://www.google.com/"),
+    ("HTTP→HTTPS 영구 이동 (301)", "http://github.com/"),
+    ("단축 URL (bit.ly → 실제 목적지)", "https://bit.ly/4tGFJkf"),
+    # --- 301 vs 302 차이 ---
+    ("301 Permanent: 주소가 영구적으로 바뀜", "https://httpbin.org/redirect-to?url=https://httpbin.org/get&status_code=301"),
+    ("302 Found: 임시로 다른 곳으로 보냄", "https://httpbin.org/redirect-to?url=https://httpbin.org/get&status_code=302"),
+    # --- 다중 hop·경로 해석 ---
+    ("다중 hop 체인 (3회 리다이렉트)", "https://httpbin.org/redirect/3"),
+    ("상대 경로 Location 해석", "https://httpbin.org/relative-redirect/2"),
+    # --- 의심 신호 탐지 ---
+    ("스킴 다운그레이드 (HTTPS→HTTP)", "https://httpbin.org/redirect-to?url=http://httpbin.org/get&status_code=302"),
+    ("크로스 오리진 (호스트 변경)", "https://httpbin.org/redirect-to?url=https://www.google.com&status_code=302"),
+    # --- 에러 ---
     ("존재하지 않는 도메인 (DNS 실패)", "https://this-domain-does-not-exist-12345.com/"),
 ]
 

--- a/tests/demo_unchain.py
+++ b/tests/demo_unchain.py
@@ -1,0 +1,60 @@
+"""URL 언체이닝 데모.
+
+사용법:
+    python -m tests.demo_unchain
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from app.services.unchainer import unchain_url
+
+DIVIDER = "-" * 72
+
+# 실제 리다이렉트가 일어나는 공개 URL들 (데모 시점에 동작 보장 불가)
+CASES: list[tuple[str, str]] = [
+    ("리다이렉트 없음", "https://www.google.com/"),
+    ("HTTP → HTTPS 업그레이드", "http://google.com/"),
+    ("단축 URL (bit.ly 예시)", "https://bit.ly/3kF8Yv2"),
+    ("t.co 단축 URL", "https://t.co/example"),
+    ("HTTP 301 리다이렉트", "http://github.com/"),
+    ("상대 경로 리다이렉트", "https://httpbin.org/relative-redirect/2"),
+    ("절대 경로 리다이렉트", "https://httpbin.org/absolute-redirect/3"),
+    ("존재하지 않는 도메인 (DNS 실패)", "https://this-domain-does-not-exist-12345.com/"),
+]
+
+
+async def main() -> None:
+    print()
+    print("=" * 72)
+    print("  LinClean -- URL Unchaining Demo")
+    print("=" * 72)
+
+    for i, (desc, url) in enumerate(CASES, 1):
+        print(f"\n  [{i:02d}] {desc}")
+        print(f"       input : {url}")
+
+        result = await unchain_url(url)
+
+        print(f"       final : {result.final_url}")
+        print(f"       hops  : {result.hop_count}")
+
+        for j, hop in enumerate(result.hops):
+            loc = f" -> {hop.location}" if hop.location else ""
+            print(f"         [{j}] {hop.method} {hop.status_code}{loc}")
+
+        if result.signals:
+            print(f"       signals: {result.signals}")
+        if result.error:
+            print(f"       error  : {result.error}")
+        if result.timed_out:
+            print("       ⚠ TIMED OUT")
+
+        print(DIVIDER)
+
+    print()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/services/unchainer/test_unchain.py
+++ b/tests/services/unchainer/test_unchain.py
@@ -19,11 +19,13 @@ def _make_response(
     headers: dict[str, str] | None = None,
 ) -> httpx.Response:
     """테스트용 httpx.Response 생성."""
-    return httpx.Response(
+    resp = httpx.Response(
         status_code=status_code,
         headers=headers or {},
         request=httpx.Request("HEAD", "https://example.com"),
     )
+    resp.aclose = AsyncMock()  # 스트리밍 close 호출 안전하게 처리
+    return resp
 
 
 def _mock_client(
@@ -31,20 +33,48 @@ def _mock_client(
     *,
     side_effect=None,
 ) -> AsyncMock:
-    """httpx.AsyncClient mock 생성. 반복되는 보일러플레이트 제거용."""
+    """httpx.AsyncClient mock 생성. 반복되는 보일러플레이트 제거용.
+
+    build_request + send(stream=True) 방식에 맞춰 mock 구성.
+    side_effect 함수는 기존과 동일하게 (method, *args, **kwargs) 시그니처.
+    """
     mock = AsyncMock()
+
+    # build_request는 동기 메서드 — 실제 httpx.Request 반환
+    mock.build_request = lambda method, url, **kw: httpx.Request(method, url, **kw)
+
     if side_effect is not None:
-        mock.request = AsyncMock(side_effect=side_effect)
+        if isinstance(side_effect, BaseException):
+            mock.send = AsyncMock(side_effect=side_effect)
+        else:
+            _original = side_effect
+
+            async def _send_wrapper(req, **kwargs):
+                if asyncio.iscoroutinefunction(_original):
+                    return await _original(req.method, str(req.url))
+                return _original(req.method, str(req.url))
+
+            mock.send = AsyncMock(side_effect=_send_wrapper)
     elif responses is not None:
-        mock.request = AsyncMock(side_effect=responses)
+        mock.send = AsyncMock(side_effect=responses)
     else:
-        mock.request = AsyncMock(return_value=_make_response(200))
+        mock.send = AsyncMock(return_value=_make_response(200))
+
     mock.__aenter__ = AsyncMock(return_value=mock)
     mock.__aexit__ = AsyncMock(return_value=False)
     return mock
 
 
 _PATCH_TARGET = "app.services.unchainer.unchain.httpx.AsyncClient"
+
+
+@pytest.fixture(autouse=True)
+def _bypass_host_safety(monkeypatch):
+    """기본적으로 SSRF 검사를 우회 — SSRF 전용 테스트에서만 직접 패치."""
+    monkeypatch.setattr(
+        "app.services.unchainer.unchain._check_host_safety",
+        AsyncMock(return_value=None),
+    )
 
 
 class TestBasicChain:
@@ -435,3 +465,133 @@ class TestHopRecording:
 
             assert result.hops[0].status_code == code, f"Failed for status {code}"
             assert result.final_url == "https://example.com/dest"
+
+
+class TestSsrfProtection:
+    """SSRF·DNS Rebinding 방어."""
+
+    @pytest.mark.asyncio
+    async def test_loopback_blocked(self) -> None:
+        """127.0.0.1 등 루프백 주소 차단."""
+        with patch(
+            "app.services.unchainer.unchain._check_host_safety",
+            new_callable=AsyncMock,
+            return_value="ssrf_blocked",
+        ):
+            result = await unchain_url("http://127.0.0.1/admin")
+
+        assert result.error == "ssrf_blocked"
+        assert "ssrf_blocked" in result.signals
+        assert result.hop_count == 0
+
+    @pytest.mark.asyncio
+    async def test_private_ip_blocked(self) -> None:
+        """사설 IP 대역(10.x, 172.16.x, 192.168.x) 차단."""
+        for url in (
+            "http://10.0.0.1/",
+            "http://172.16.0.1/",
+            "http://192.168.1.1/",
+        ):
+            with patch(
+                "app.services.unchainer.unchain._check_host_safety",
+                new_callable=AsyncMock,
+                return_value="ssrf_blocked",
+            ):
+                result = await unchain_url(url)
+
+            assert result.error == "ssrf_blocked", f"Failed for {url}"
+            assert "ssrf_blocked" in result.signals
+
+    @pytest.mark.asyncio
+    async def test_metadata_endpoint_blocked(self) -> None:
+        """클라우드 메타데이터 엔드포인트(169.254.169.254) 차단."""
+        with patch(
+            "app.services.unchainer.unchain._check_host_safety",
+            new_callable=AsyncMock,
+            return_value="ssrf_blocked",
+        ):
+            result = await unchain_url("http://169.254.169.254/latest/meta-data/")
+
+        assert result.error == "ssrf_blocked"
+        assert "ssrf_blocked" in result.signals
+
+    @pytest.mark.asyncio
+    async def test_redirect_to_internal_blocked(self) -> None:
+        """외부 URL이 내부 IP로 리다이렉트할 때 두 번째 hop에서 차단."""
+        safety_call_count = 0
+
+        async def _safety_per_hop(url: str) -> str | None:
+            nonlocal safety_call_count
+            safety_call_count += 1
+            # 첫 번째 hop은 통과, 두 번째(내부 IP)는 차단
+            if "internal" in url or "127.0.0.1" in url:
+                return "ssrf_blocked"
+            return None
+
+        responses = [
+            _make_response(302, {"location": "http://127.0.0.1/secret"}),
+        ]
+        client = _mock_client(responses)
+
+        with (
+            patch(_PATCH_TARGET, return_value=client),
+            patch(
+                "app.services.unchainer.unchain._check_host_safety",
+                side_effect=_safety_per_hop,
+            ),
+        ):
+            result = await unchain_url("https://evil.com/redirect")
+
+        assert result.error == "ssrf_blocked"
+        assert "ssrf_blocked" in result.signals
+
+    @pytest.mark.asyncio
+    async def test_public_url_passes(self) -> None:
+        """공개 IP는 정상 통과."""
+        client = _mock_client([_make_response(200)])
+
+        with (
+            patch(_PATCH_TARGET, return_value=client),
+            patch(
+                "app.services.unchainer.unchain._check_host_safety",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            result = await unchain_url("https://example.com/")
+
+        assert result.error is None
+        assert "ssrf_blocked" not in result.signals
+
+
+class TestIsPrivateIp:
+    """_is_private_ip 단위 테스트."""
+
+    def test_loopback(self) -> None:
+        from app.services.unchainer.unchain import _is_private_ip
+
+        assert _is_private_ip("127.0.0.1") is True
+        assert _is_private_ip("::1") is True
+
+    def test_private_ranges(self) -> None:
+        from app.services.unchainer.unchain import _is_private_ip
+
+        assert _is_private_ip("10.0.0.1") is True
+        assert _is_private_ip("172.16.0.1") is True
+        assert _is_private_ip("192.168.1.1") is True
+
+    def test_link_local(self) -> None:
+        from app.services.unchainer.unchain import _is_private_ip
+
+        assert _is_private_ip("169.254.169.254") is True
+
+    def test_public_ip(self) -> None:
+        from app.services.unchainer.unchain import _is_private_ip
+
+        assert _is_private_ip("8.8.8.8") is False
+        assert _is_private_ip("1.1.1.1") is False
+
+    def test_invalid_ip(self) -> None:
+        from app.services.unchainer.unchain import _is_private_ip
+
+        assert _is_private_ip("not-an-ip") is True

--- a/tests/services/unchainer/test_unchain.py
+++ b/tests/services/unchainer/test_unchain.py
@@ -5,9 +5,12 @@ httpx.AsyncClient를 모킹해서 네트워크 요청 없이 리다이렉트 체
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import httpx
+import pytest
+
 from app.services.unchainer.unchain import unchain_url
 
 
@@ -23,16 +26,35 @@ def _make_response(
     )
 
 
+def _mock_client(
+    responses: list[httpx.Response] | None = None,
+    *,
+    side_effect=None,
+) -> AsyncMock:
+    """httpx.AsyncClient mock 생성. 반복되는 보일러플레이트 제거용."""
+    mock = AsyncMock()
+    if side_effect is not None:
+        mock.request = AsyncMock(side_effect=side_effect)
+    elif responses is not None:
+        mock.request = AsyncMock(side_effect=responses)
+    else:
+        mock.request = AsyncMock(return_value=_make_response(200))
+    mock.__aenter__ = AsyncMock(return_value=mock)
+    mock.__aexit__ = AsyncMock(return_value=False)
+    return mock
+
+
+_PATCH_TARGET = "app.services.unchainer.unchain.httpx.AsyncClient"
+
+
 class TestBasicChain:
     """리다이렉트 없는 경우 / 단일·다중 hop 체인."""
 
+    @pytest.mark.asyncio
     async def test_no_redirect(self) -> None:
-        mock_client = AsyncMock()
-        mock_client.request = AsyncMock(return_value=_make_response(200))
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
+        client = _mock_client([_make_response(200)])
 
-        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+        with patch(_PATCH_TARGET, return_value=client):
             result = await unchain_url("https://example.com/")
 
         assert result.final_url == "https://example.com/"
@@ -41,17 +63,15 @@ class TestBasicChain:
         assert result.error is None
         assert not result.signals
 
+    @pytest.mark.asyncio
     async def test_single_redirect(self) -> None:
         responses = [
             _make_response(301, {"location": "https://example.com/new"}),
             _make_response(200),
         ]
-        mock_client = AsyncMock()
-        mock_client.request = AsyncMock(side_effect=responses)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
+        client = _mock_client(responses)
 
-        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+        with patch(_PATCH_TARGET, return_value=client):
             result = await unchain_url("https://example.com/old")
 
         assert result.final_url == "https://example.com/new"
@@ -60,6 +80,7 @@ class TestBasicChain:
         assert result.hops[0].location == "https://example.com/new"
         assert result.hops[1].status_code == 200
 
+    @pytest.mark.asyncio
     async def test_multi_hop_chain(self) -> None:
         responses = [
             _make_response(302, {"location": "https://a.com/2"}),
@@ -67,12 +88,9 @@ class TestBasicChain:
             _make_response(302, {"location": "https://a.com/final"}),
             _make_response(200),
         ]
-        mock_client = AsyncMock()
-        mock_client.request = AsyncMock(side_effect=responses)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
+        client = _mock_client(responses)
 
-        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+        with patch(_PATCH_TARGET, return_value=client):
             result = await unchain_url("https://a.com/1")
 
         assert result.final_url == "https://a.com/final"
@@ -82,18 +100,16 @@ class TestBasicChain:
 class TestRedirectLoop:
     """무한 루프 감지."""
 
+    @pytest.mark.asyncio
     async def test_loop_detected(self) -> None:
         """A → B → A 루프 감지 시 redirect_loop 신호."""
         responses = [
             _make_response(302, {"location": "https://b.com/"}),
             _make_response(302, {"location": "https://a.com/"}),
         ]
-        mock_client = AsyncMock()
-        mock_client.request = AsyncMock(side_effect=responses)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
+        client = _mock_client(responses)
 
-        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+        with patch(_PATCH_TARGET, return_value=client):
             result = await unchain_url("https://a.com/")
 
         assert "redirect_loop" in result.signals
@@ -103,12 +119,8 @@ class TestRedirectLoop:
 class TestMaxHops:
     """hop 수 제한."""
 
+    @pytest.mark.asyncio
     async def test_max_hops_reached(self) -> None:
-        def _redirect(request: httpx.Request) -> httpx.Response:
-            return _make_response(302, {"location": "https://example.com/next"})
-
-        # 무한 리다이렉트지만 URL이 매번 같으므로 루프 감지가 먼저 발동됨.
-        # URL을 매 hop마다 다르게 생성해야 max_hops 테스트 가능.
         hop_count = 0
 
         def _side_effect(*args: object, **kwargs: object) -> httpx.Response:
@@ -118,18 +130,16 @@ class TestMaxHops:
                 302, {"location": f"https://example.com/{hop_count}"},
             )
 
-        mock_client = AsyncMock()
-        mock_client.request = AsyncMock(side_effect=_side_effect)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
+        client = _mock_client(side_effect=_side_effect)
 
         with (
-            patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client),
+            patch(_PATCH_TARGET, return_value=client),
             patch("app.services.unchainer.unchain.settings") as mock_settings,
         ):
             mock_settings.unchain_max_hops = 5
-            mock_settings.unchain_timeout_seconds = 10.0
-            mock_settings.unchain_per_hop_timeout_seconds = 5.0
+            mock_settings.unchain_timeout_seconds = 5.0
+            mock_settings.unchain_connect_timeout_seconds = 3.0
+            mock_settings.unchain_chain_timeout_seconds = 20.0
             mock_settings.unchain_user_agent = "test-agent"
             result = await unchain_url("https://example.com/start")
 
@@ -140,32 +150,28 @@ class TestMaxHops:
 class TestSchemeDowngrade:
     """https → http 스킴 다운그레이드 감지."""
 
+    @pytest.mark.asyncio
     async def test_scheme_downgrade_signal(self) -> None:
         responses = [
             _make_response(302, {"location": "http://example.com/insecure"}),
             _make_response(200),
         ]
-        mock_client = AsyncMock()
-        mock_client.request = AsyncMock(side_effect=responses)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
+        client = _mock_client(responses)
 
-        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+        with patch(_PATCH_TARGET, return_value=client):
             result = await unchain_url("https://example.com/")
 
         assert "scheme_downgrade" in result.signals
 
+    @pytest.mark.asyncio
     async def test_no_signal_on_http_to_https(self) -> None:
         responses = [
             _make_response(302, {"location": "https://example.com/secure"}),
             _make_response(200),
         ]
-        mock_client = AsyncMock()
-        mock_client.request = AsyncMock(side_effect=responses)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
+        client = _mock_client(responses)
 
-        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+        with patch(_PATCH_TARGET, return_value=client):
             result = await unchain_url("http://example.com/")
 
         assert "scheme_downgrade" not in result.signals
@@ -174,17 +180,15 @@ class TestSchemeDowngrade:
 class TestCrossOrigin:
     """크로스 오리진 호스트 변화 감지."""
 
+    @pytest.mark.asyncio
     async def test_cross_origin_signal(self) -> None:
         responses = [
             _make_response(302, {"location": "https://evil.com/phish"}),
             _make_response(200),
         ]
-        mock_client = AsyncMock()
-        mock_client.request = AsyncMock(side_effect=responses)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
+        client = _mock_client(responses)
 
-        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+        with patch(_PATCH_TARGET, return_value=client):
             result = await unchain_url("https://safe.com/link")
 
         assert any(s.startswith("cross_origin:") for s in result.signals)
@@ -194,37 +198,87 @@ class TestCrossOrigin:
 class TestRelativeLocation:
     """상대 경로 Location 해석."""
 
+    @pytest.mark.asyncio
     async def test_relative_path_resolved(self) -> None:
         responses = [
             _make_response(302, {"location": "/new-path"}),
             _make_response(200),
         ]
-        mock_client = AsyncMock()
-        mock_client.request = AsyncMock(side_effect=responses)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
+        client = _mock_client(responses)
 
-        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+        with patch(_PATCH_TARGET, return_value=client):
             result = await unchain_url("https://example.com/old-path")
 
         assert result.final_url == "https://example.com/new-path"
+        assert result.hops[0].location == "https://example.com/new-path"
+
+    @pytest.mark.asyncio
+    async def test_raw_location_preserved(self) -> None:
+        """상대 경로 원본 값이 raw_location에 보존되는지 확인."""
+        responses = [
+            _make_response(302, {"location": "/new-path"}),
+            _make_response(200),
+        ]
+        client = _mock_client(responses)
+
+        with patch(_PATCH_TARGET, return_value=client):
+            result = await unchain_url("https://example.com/old-path")
+
+        assert result.hops[0].raw_location == "/new-path"
         assert result.hops[0].location == "https://example.com/new-path"
 
 
 class TestHeadFallback:
     """HEAD 실패 시 GET 폴백."""
 
+    @pytest.mark.asyncio
     async def test_head_405_falls_back_to_get(self) -> None:
         responses = [
             _make_response(405),  # HEAD 실패
             _make_response(200),  # GET 성공
         ]
-        mock_client = AsyncMock()
-        mock_client.request = AsyncMock(side_effect=responses)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
+        client = _mock_client(responses)
 
-        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+        with patch(_PATCH_TARGET, return_value=client):
+            result = await unchain_url("https://example.com/")
+
+        assert result.hop_count == 1
+        assert result.hops[0].method == "GET"
+        assert result.error is None
+
+    @pytest.mark.asyncio
+    async def test_head_timeout_falls_back_to_get(self) -> None:
+        """HEAD에서 타임아웃 → GET으로 폴백해서 성공."""
+        call_count = 0
+
+        def _side_effect(method: str, *args: object, **kwargs: object) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            if method == "HEAD":
+                raise httpx.ReadTimeout("timed out")
+            return _make_response(200)
+
+        client = _mock_client(side_effect=_side_effect)
+
+        with patch(_PATCH_TARGET, return_value=client):
+            result = await unchain_url("https://example.com/")
+
+        assert result.hop_count == 1
+        assert result.hops[0].method == "GET"
+        assert result.error is None
+
+    @pytest.mark.asyncio
+    async def test_head_connect_error_falls_back_to_get(self) -> None:
+        """HEAD에서 ConnectError → GET으로 폴백해서 성공."""
+
+        def _side_effect(method: str, *args: object, **kwargs: object) -> httpx.Response:
+            if method == "HEAD":
+                raise httpx.ConnectError("Connection refused")
+            return _make_response(200)
+
+        client = _mock_client(side_effect=_side_effect)
+
+        with patch(_PATCH_TARGET, return_value=client):
             result = await unchain_url("https://example.com/")
 
         assert result.hop_count == 1
@@ -235,92 +289,138 @@ class TestHeadFallback:
 class TestErrorHandling:
     """네트워크·서버 에러 처리."""
 
+    @pytest.mark.asyncio
     async def test_timeout_error(self) -> None:
-        mock_client = AsyncMock()
-        mock_client.request = AsyncMock(side_effect=httpx.ReadTimeout("timed out"))
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
+        """HEAD·GET 모두 타임아웃이면 최종 에러."""
+        client = _mock_client(side_effect=httpx.ReadTimeout("timed out"))
 
-        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+        with patch(_PATCH_TARGET, return_value=client):
             result = await unchain_url("https://slow.example.com/")
 
         assert result.timed_out is True
         assert result.error == "timeout"
 
+    @pytest.mark.asyncio
     async def test_dns_failure_via_connect_error(self) -> None:
-        mock_client = AsyncMock()
-        mock_client.request = AsyncMock(
-            side_effect=httpx.ConnectError(
-                "[Errno -2] Name or service not known",
-            ),
+        client = _mock_client(
+            side_effect=httpx.ConnectError("[Errno -2] Name or service not known"),
         )
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+        with patch(_PATCH_TARGET, return_value=client):
             result = await unchain_url("https://nonexistent.invalid/")
 
         assert result.error == "dns_failure"
 
+    @pytest.mark.asyncio
     async def test_connection_refused(self) -> None:
-        mock_client = AsyncMock()
-        mock_client.request = AsyncMock(
+        client = _mock_client(
             side_effect=httpx.ConnectError("Connection refused"),
         )
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+        with patch(_PATCH_TARGET, return_value=client):
             result = await unchain_url("https://refused.example.com/")
 
         assert result.error is not None
         assert "connection_refused" in result.error
 
+    @pytest.mark.asyncio
     async def test_server_error_5xx(self) -> None:
-        mock_client = AsyncMock()
-        mock_client.request = AsyncMock(return_value=_make_response(503))
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
+        client = _mock_client([_make_response(503)])
 
-        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+        with patch(_PATCH_TARGET, return_value=client):
             result = await unchain_url("https://down.example.com/")
 
         assert result.error == "server_error_503"
         assert result.hop_count == 1
         assert result.hops[0].status_code == 503
 
+    @pytest.mark.asyncio
     async def test_missing_location_header(self) -> None:
-        mock_client = AsyncMock()
-        mock_client.request = AsyncMock(return_value=_make_response(302))
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
+        client = _mock_client([_make_response(302)])
 
-        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+        with patch(_PATCH_TARGET, return_value=client):
             result = await unchain_url("https://broken.example.com/")
 
         assert result.error == "missing_location_header"
 
 
+class TestChainTimeout:
+    """전체 체인 총 timeout."""
+
+    @pytest.mark.asyncio
+    async def test_chain_timeout(self) -> None:
+        """hop별로는 안 터지지만 전체 체인이 총 timeout을 초과하면 중단."""
+
+        async def _slow_request(*args: object, **kwargs: object) -> httpx.Response:
+            await asyncio.sleep(10)
+            return _make_response(302, {"location": "https://example.com/next"})
+
+        client = _mock_client(side_effect=_slow_request)
+
+        with (
+            patch(_PATCH_TARGET, return_value=client),
+            patch("app.services.unchainer.unchain.settings") as mock_settings,
+        ):
+            mock_settings.unchain_max_hops = 20
+            mock_settings.unchain_timeout_seconds = 5.0
+            mock_settings.unchain_connect_timeout_seconds = 3.0
+            mock_settings.unchain_chain_timeout_seconds = 0.1
+            mock_settings.unchain_user_agent = "test-agent"
+            result = await unchain_url("https://example.com/start")
+
+        assert result.timed_out is True
+        assert result.error == "chain_timeout"
+
+
+class TestUnsafeScheme:
+    """javascript:, data: 등 비허용 스킴 리다이렉트 차단."""
+
+    @pytest.mark.asyncio
+    async def test_javascript_scheme_blocked(self) -> None:
+        responses = [
+            _make_response(302, {"location": "javascript:alert(1)"}),
+        ]
+        client = _mock_client(responses)
+
+        with patch(_PATCH_TARGET, return_value=client):
+            result = await unchain_url("https://example.com/")
+
+        assert result.error == "unsafe_redirect_scheme:javascript"
+        assert "unsafe_scheme:javascript" in result.signals
+
+    @pytest.mark.asyncio
+    async def test_data_scheme_blocked(self) -> None:
+        responses = [
+            _make_response(302, {"location": "data:text/html,<h1>phish</h1>"}),
+        ]
+        client = _mock_client(responses)
+
+        with patch(_PATCH_TARGET, return_value=client):
+            result = await unchain_url("https://example.com/")
+
+        assert result.error == "unsafe_redirect_scheme:data"
+        assert "unsafe_scheme:data" in result.signals
+
+
 class TestHopRecording:
     """hop 기록 정확성."""
 
+    @pytest.mark.asyncio
     async def test_hop_records_method_and_url(self) -> None:
         responses = [
             _make_response(302, {"location": "https://b.com/"}),
             _make_response(200),
         ]
-        mock_client = AsyncMock()
-        mock_client.request = AsyncMock(side_effect=responses)
-        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-        mock_client.__aexit__ = AsyncMock(return_value=False)
+        client = _mock_client(responses)
 
-        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+        with patch(_PATCH_TARGET, return_value=client):
             result = await unchain_url("https://a.com/")
 
         assert result.hops[0].url == "https://a.com/"
         assert result.hops[0].method == "HEAD"
         assert result.hops[1].url == "https://b.com/"
 
+    @pytest.mark.asyncio
     async def test_all_redirect_status_codes(self) -> None:
         """301, 302, 303, 307, 308 모두 리다이렉트로 처리."""
         for code in (301, 302, 303, 307, 308):
@@ -328,15 +428,9 @@ class TestHopRecording:
                 _make_response(code, {"location": "https://example.com/dest"}),
                 _make_response(200),
             ]
-            mock_client = AsyncMock()
-            mock_client.request = AsyncMock(side_effect=responses)
-            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
-            mock_client.__aexit__ = AsyncMock(return_value=False)
+            client = _mock_client(responses)
 
-            with patch(
-                "app.services.unchainer.unchain.httpx.AsyncClient",
-                return_value=mock_client,
-            ):
+            with patch(_PATCH_TARGET, return_value=client):
                 result = await unchain_url("https://example.com/src")
 
             assert result.hops[0].status_code == code, f"Failed for status {code}"

--- a/tests/services/unchainer/test_unchain.py
+++ b/tests/services/unchainer/test_unchain.py
@@ -1,0 +1,343 @@
+"""unchain_url 단위 테스트.
+
+httpx.AsyncClient를 모킹해서 네트워크 요청 없이 리다이렉트 체인 로직을 검증.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+from app.services.unchainer.unchain import unchain_url
+
+
+def _make_response(
+    status_code: int = 200,
+    headers: dict[str, str] | None = None,
+) -> httpx.Response:
+    """테스트용 httpx.Response 생성."""
+    return httpx.Response(
+        status_code=status_code,
+        headers=headers or {},
+        request=httpx.Request("HEAD", "https://example.com"),
+    )
+
+
+class TestBasicChain:
+    """리다이렉트 없는 경우 / 단일·다중 hop 체인."""
+
+    async def test_no_redirect(self) -> None:
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(return_value=_make_response(200))
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+            result = await unchain_url("https://example.com/")
+
+        assert result.final_url == "https://example.com/"
+        assert result.hop_count == 1
+        assert result.hops[0].status_code == 200
+        assert result.error is None
+        assert not result.signals
+
+    async def test_single_redirect(self) -> None:
+        responses = [
+            _make_response(301, {"location": "https://example.com/new"}),
+            _make_response(200),
+        ]
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(side_effect=responses)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+            result = await unchain_url("https://example.com/old")
+
+        assert result.final_url == "https://example.com/new"
+        assert result.hop_count == 2
+        assert result.hops[0].status_code == 301
+        assert result.hops[0].location == "https://example.com/new"
+        assert result.hops[1].status_code == 200
+
+    async def test_multi_hop_chain(self) -> None:
+        responses = [
+            _make_response(302, {"location": "https://a.com/2"}),
+            _make_response(302, {"location": "https://a.com/3"}),
+            _make_response(302, {"location": "https://a.com/final"}),
+            _make_response(200),
+        ]
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(side_effect=responses)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+            result = await unchain_url("https://a.com/1")
+
+        assert result.final_url == "https://a.com/final"
+        assert result.hop_count == 4
+
+
+class TestRedirectLoop:
+    """무한 루프 감지."""
+
+    async def test_loop_detected(self) -> None:
+        """A → B → A 루프 감지 시 redirect_loop 신호."""
+        responses = [
+            _make_response(302, {"location": "https://b.com/"}),
+            _make_response(302, {"location": "https://a.com/"}),
+        ]
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(side_effect=responses)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+            result = await unchain_url("https://a.com/")
+
+        assert "redirect_loop" in result.signals
+        assert result.hop_count == 2
+
+
+class TestMaxHops:
+    """hop 수 제한."""
+
+    async def test_max_hops_reached(self) -> None:
+        def _redirect(request: httpx.Request) -> httpx.Response:
+            return _make_response(302, {"location": "https://example.com/next"})
+
+        # 무한 리다이렉트지만 URL이 매번 같으므로 루프 감지가 먼저 발동됨.
+        # URL을 매 hop마다 다르게 생성해야 max_hops 테스트 가능.
+        hop_count = 0
+
+        def _side_effect(*args: object, **kwargs: object) -> httpx.Response:
+            nonlocal hop_count
+            hop_count += 1
+            return _make_response(
+                302, {"location": f"https://example.com/{hop_count}"},
+            )
+
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(side_effect=_side_effect)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client),
+            patch("app.services.unchainer.unchain.settings") as mock_settings,
+        ):
+            mock_settings.unchain_max_hops = 5
+            mock_settings.unchain_timeout_seconds = 10.0
+            mock_settings.unchain_per_hop_timeout_seconds = 5.0
+            mock_settings.unchain_user_agent = "test-agent"
+            result = await unchain_url("https://example.com/start")
+
+        assert "max_hops_reached" in result.signals
+        assert result.hop_count == 5
+
+
+class TestSchemeDowngrade:
+    """https → http 스킴 다운그레이드 감지."""
+
+    async def test_scheme_downgrade_signal(self) -> None:
+        responses = [
+            _make_response(302, {"location": "http://example.com/insecure"}),
+            _make_response(200),
+        ]
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(side_effect=responses)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+            result = await unchain_url("https://example.com/")
+
+        assert "scheme_downgrade" in result.signals
+
+    async def test_no_signal_on_http_to_https(self) -> None:
+        responses = [
+            _make_response(302, {"location": "https://example.com/secure"}),
+            _make_response(200),
+        ]
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(side_effect=responses)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+            result = await unchain_url("http://example.com/")
+
+        assert "scheme_downgrade" not in result.signals
+
+
+class TestCrossOrigin:
+    """크로스 오리진 호스트 변화 감지."""
+
+    async def test_cross_origin_signal(self) -> None:
+        responses = [
+            _make_response(302, {"location": "https://evil.com/phish"}),
+            _make_response(200),
+        ]
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(side_effect=responses)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+            result = await unchain_url("https://safe.com/link")
+
+        assert any(s.startswith("cross_origin:") for s in result.signals)
+        assert "cross_origin:safe.com->evil.com" in result.signals
+
+
+class TestRelativeLocation:
+    """상대 경로 Location 해석."""
+
+    async def test_relative_path_resolved(self) -> None:
+        responses = [
+            _make_response(302, {"location": "/new-path"}),
+            _make_response(200),
+        ]
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(side_effect=responses)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+            result = await unchain_url("https://example.com/old-path")
+
+        assert result.final_url == "https://example.com/new-path"
+        assert result.hops[0].location == "https://example.com/new-path"
+
+
+class TestHeadFallback:
+    """HEAD 실패 시 GET 폴백."""
+
+    async def test_head_405_falls_back_to_get(self) -> None:
+        responses = [
+            _make_response(405),  # HEAD 실패
+            _make_response(200),  # GET 성공
+        ]
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(side_effect=responses)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+            result = await unchain_url("https://example.com/")
+
+        assert result.hop_count == 1
+        assert result.hops[0].method == "GET"
+        assert result.error is None
+
+
+class TestErrorHandling:
+    """네트워크·서버 에러 처리."""
+
+    async def test_timeout_error(self) -> None:
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(side_effect=httpx.ReadTimeout("timed out"))
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+            result = await unchain_url("https://slow.example.com/")
+
+        assert result.timed_out is True
+        assert result.error == "timeout"
+
+    async def test_dns_failure_via_connect_error(self) -> None:
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(
+            side_effect=httpx.ConnectError(
+                "[Errno -2] Name or service not known",
+            ),
+        )
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+            result = await unchain_url("https://nonexistent.invalid/")
+
+        assert result.error == "dns_failure"
+
+    async def test_connection_refused(self) -> None:
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(
+            side_effect=httpx.ConnectError("Connection refused"),
+        )
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+            result = await unchain_url("https://refused.example.com/")
+
+        assert result.error is not None
+        assert "connection_refused" in result.error
+
+    async def test_server_error_5xx(self) -> None:
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(return_value=_make_response(503))
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+            result = await unchain_url("https://down.example.com/")
+
+        assert result.error == "server_error_503"
+        assert result.hop_count == 1
+        assert result.hops[0].status_code == 503
+
+    async def test_missing_location_header(self) -> None:
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(return_value=_make_response(302))
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+            result = await unchain_url("https://broken.example.com/")
+
+        assert result.error == "missing_location_header"
+
+
+class TestHopRecording:
+    """hop 기록 정확성."""
+
+    async def test_hop_records_method_and_url(self) -> None:
+        responses = [
+            _make_response(302, {"location": "https://b.com/"}),
+            _make_response(200),
+        ]
+        mock_client = AsyncMock()
+        mock_client.request = AsyncMock(side_effect=responses)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.unchainer.unchain.httpx.AsyncClient", return_value=mock_client):
+            result = await unchain_url("https://a.com/")
+
+        assert result.hops[0].url == "https://a.com/"
+        assert result.hops[0].method == "HEAD"
+        assert result.hops[1].url == "https://b.com/"
+
+    async def test_all_redirect_status_codes(self) -> None:
+        """301, 302, 303, 307, 308 모두 리다이렉트로 처리."""
+        for code in (301, 302, 303, 307, 308):
+            responses = [
+                _make_response(code, {"location": "https://example.com/dest"}),
+                _make_response(200),
+            ]
+            mock_client = AsyncMock()
+            mock_client.request = AsyncMock(side_effect=responses)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+
+            with patch(
+                "app.services.unchainer.unchain.httpx.AsyncClient",
+                return_value=mock_client,
+            ):
+                result = await unchain_url("https://example.com/src")
+
+            assert result.hops[0].status_code == code, f"Failed for status {code}"
+            assert result.final_url == "https://example.com/dest"

--- a/tests/services/unchainer/test_unchain.py
+++ b/tests/services/unchainer/test_unchain.py
@@ -298,6 +298,28 @@ class TestHeadFallback:
         assert result.error is None
 
     @pytest.mark.asyncio
+    async def test_head_redirect_without_location_falls_back_to_get(self) -> None:
+        """HEAD가 리다이렉트인데 Location 누락 → GET으로 폴백해서 체인 추적."""
+
+        def _side_effect(method: str, url: str) -> httpx.Response:
+            if url == "https://example.com/start":
+                # HEAD는 301인데 Location 헤더 생략, GET은 정상 응답
+                if method == "HEAD":
+                    return _make_response(301)
+                return _make_response(301, {"location": "https://example.com/final"})
+            return _make_response(200)
+
+        client = _mock_client(side_effect=_side_effect)
+
+        with patch(_PATCH_TARGET, return_value=client):
+            result = await unchain_url("https://example.com/start")
+
+        assert result.error is None
+        assert result.final_url == "https://example.com/final"
+        assert result.hops[0].method == "GET"
+        assert result.hops[0].status_code == 301
+
+    @pytest.mark.asyncio
     async def test_head_connect_error_falls_back_to_get(self) -> None:
         """HEAD에서 ConnectError → GET으로 폴백해서 성공."""
 
@@ -366,7 +388,8 @@ class TestErrorHandling:
 
     @pytest.mark.asyncio
     async def test_missing_location_header(self) -> None:
-        client = _mock_client([_make_response(302)])
+        # HEAD·GET 모두 Location 헤더 누락 — 최종적으로 missing_location_header
+        client = _mock_client([_make_response(302), _make_response(302)])
 
         with patch(_PATCH_TARGET, return_value=client):
             result = await unchain_url("https://broken.example.com/")


### PR DESCRIPTION
# 요약

단축 URL(bit.ly, t.ly 등)이나 리다이렉트 체인을 끝까지 따라가서 **최종 목적지 URL**을 알아내는 기능입니다.
(악성 URL은 여러 번의 리다이렉트를 거쳐 최종 목적지를 숨기는 경우가 많기 때문)

## 단축 URL 예시 (실제 피해 사례)
<img width="473" height="393" alt="스크린샷 2026-04-13 오후 12 13 58" src="https://github.com/user-attachments/assets/45badd12-e489-4cbc-89cf-36fea399b881" />
<img width="616" height="159" alt="스크린샷 2026-04-13 오후 12 15 22" src="https://github.com/user-attachments/assets/e44c8199-e4f4-48f8-8cac-981cd220ec29" />

## 리다이렉트 예시
1. http://bit.ly/abc123 접속
2. 301 응답 → https://tracking.example.com/click?id=99                                                                                                                       
3. 302 응답 → https://real-destination.com/page    

# 구현 상세

  ## 동작 원리                                
                                          
  1. 입력받은 URL의 호스트를 DNS 조회하여 내부 IP 대역인지 확인합니다 (SSRF 방어)
  2. 안전한 경우 HTTP 요청(HEAD 우선, 실패 시 GET 폴백)을 보냅니다                                                                                                         
  3. 서버가 리다이렉트(301, 302, 303, 307, 308) 응답을 주면 `Location` 헤더를 따라 다음 URL로 이동합니다
  4. 매 hop마다 1번의 IP 검증을 반복하여 DNS Rebinding 공격을 방어합니다                                                                                                   
  5. 리다이렉트가 끝나거나, 최대 hop 수에 도달하면 추적을 멈춥니다
  6. 각 hop 기록과 함께 아래 **의심 신호**를 자동 탐지합니다(위험도가 높은 신호(`ssrf_blocked`, `unsafe_scheme`, `redirect_loop`)는 체인을 즉시 중단하고, 나머지(`scheme_downgrade`, `cross_origin`)는 기록 후 추적을 계속합니다):                                                                                                              
     - `scheme_downgrade` — HTTPS에서 HTTP로 다운그레이드 (중간자 공격 노출 위험)
     - `cross_origin` — 호스트가 바뀌는 리다이렉트 (피싱 의심)                                                                                                             
     - `redirect_loop` — 무한 루프 감지                                                                                                                                    
     - `unsafe_scheme` — javascript:, data: 등 위험한 스킴으로의 리다이렉트 차단                                                                                           
     - `max_hops_reached` — 비정상적으로 긴 리다이렉트 체인                                                                                                                
     - `ssrf_blocked` — 내부 네트워크 대상 요청 차단  

## scheme_downgrade + cross_origin 동시 발생 예시
```json
{                                                                                                                                                                        
    "input_url": "https://safe-bank.com/login",                                                                                                                            
    "final_url": "http://phishing-site.com/fake-login",
    "hops": [                                                                                                                                                              
      {                                   
        "url": "https://safe-bank.com/login",                                                                                                                              
        "status_code": 302,                                                                                                                                                
        "raw_location": "http://phishing-site.com/fake-login",                                                                                                             
        "location": "http://phishing-site.com/fake-login",                                                                                                                 
        "method": "HEAD"                      
      },                                                                                                                                                                   
      {
        "url": "http://phishing-site.com/fake-login",                                                                                                                      
        "status_code": 200,
        "raw_location": null,                                                                                                                                              
        "location": null,                 
        "method": "HEAD"
      }                                                                                                                                                                    
    ],
    "hop_count": 2,                                                                                                                                                        
    "timed_out": false,
    "error": null,                            
    "signals": [                          
      "scheme_downgrade",
      "cross_origin:safe-bank.com->phishing-site.com"                                                                                                                      
    ]                                         
}
```                                                                                                           
                                                                                                                                                                           
  ## 변경 파일                                                                                                                                                             
                                                                                                                                                                           
  | 파일 | 설명 |                                                                                                                                                          
  |------|------|                                                                                                                                                          
  | `app/services/unchainer/unchain.py` | 언체이닝 핵심 로직 (비동기, httpx 기반) + SSRF·DNS Rebinding·응답 본문 메모리 방어 |                                             
  | `app/schemas/analysis.py` | `HopRecord`, `UnchainResult` 스키마 추가 |
  | `app/core/config.py` | 타임아웃, max_hops 등 설정값 추가 |
  | `tests/services/unchainer/test_unchain.py` | 단위 테스트 33건 (SSRF 방어 10건 포함) |
  | `tests/demo/demo_unchain.py` | 언체이닝 데모 스크립트 (301/302 비교, 신호 탐지 등 10개 시나리오) |                                                                     
  | `README.md` | 언체이닝 모듈 문서 반영 |   


# 연관 이슈 및 Close 할 이슈

#6 
close #6 

# TEST

## TEST 코드 (python -m pytest tests/services/unchainer/test_unchain.py -v)
<img width="1372" height="772" alt="스크린샷 2026-04-13 오후 1 17 46" src="https://github.com/user-attachments/assets/bdb61f84-7d01-463f-8757-2c5d5368de4c" />
<img width="1367" height="218" alt="스크린샷 2026-04-13 오후 1 18 04" src="https://github.com/user-attachments/assets/9dd68ff7-8881-4057-b1aa-fd7bfa255b73" />

## DEMO
<img width="1381" height="314" alt="스크린샷 2026-04-13 오후 1 42 48" src="https://github.com/user-attachments/assets/1ca20435-85a4-4296-a26f-cdd3fe8969e8" />
<img width="1382" height="490" alt="스크린샷 2026-04-13 오후 1 43 04" src="https://github.com/user-attachments/assets/a49925ef-98e0-43ba-b104-dffca6dd5a41" />
<img width="1378" height="571" alt="스크린샷 2026-04-13 오후 1 43 37" src="https://github.com/user-attachments/assets/7a4144fe-0adb-48cd-a6a9-2940eabbfcd0" />
<img width="1369" height="611" alt="스크린샷 2026-04-13 오후 1 44 14" src="https://github.com/user-attachments/assets/b810b449-67c6-46f9-b5a7-f56dcbbdf68f" />
<img width="1380" height="364" alt="스크린샷 2026-04-13 오후 1 44 51" src="https://github.com/user-attachments/assets/055e69fa-8348-4a7b-991b-3ba8040fb6e6" />

## DEMO 결과

  [01] 리다이렉트 없음 (200 OK)

  - HEAD 200 — 서버가 바로 정상 응답. 리다이렉트 없이 입력 URL이 곧 최종 URL
  - 가장 단순한 케이스로, 언체이닝할 체인 자체가 없음

  [02] HTTP→HTTPS 영구 이동 (301)

  - http://github.com → https://github.com으로 301 리다이렉트
  - 보안을 위해 HTTP 접속을 HTTPS로 강제 전환하는 가장 흔한 패턴
  - 브라우저 주소창에 github.com만 치면 내부적으로 이 리다이렉트가 일어남

  [03] 단축 URL (bit.ly → 실제 목적지)

  - bit.ly/4tGFJkf라는 짧은 URL 뒤에 구글 이미지 검색이라는 긴 최종 URL이 숨어 있음
  - cross_origin 신호: 호스트가 bit.ly → www.google.com으로 완전히 바뀜
  - 언체이닝의 핵심 사용 사례 — 클릭 전에 실제 목적지를 미리 확인 가능

  [04] 301 Permanent: 주소가 영구적으로 바뀜

  - httpbin이 301로 /get으로 리다이렉트
  - 301은 "이 주소는 영구적으로 이전됨"을 의미 — 브라우저가 결과를 캐싱하여 다음에는 원래 URL에 다시 물어보지 않음
  - 도메인 이전, HTTP→HTTPS 전환 등에 사용

  [05] 302 Found: 임시로 다른 곳으로 보냄

  - 04번과 동일한 목적지지만 302로 리다이렉트
  - 302는 "지금은 임시로 여기로 가라"는 의미 — 매번 원래 URL에 다시 물어봄
  - 로그인 후 리다이렉트, 트래킹 링크, A/B 테스트 등에 사용
  - 피싱·광고 추적에 악용되기 쉬운 코드

  [06] 다중 hop 체인 (3회 리다이렉트)

  - /redirect/3 → /relative-redirect/2 → /relative-redirect/1 → /get → 200
  - 총 4 hop (리다이렉트 3회 + 최종 응답 1회)
  - 실제 악성 URL도 여러 중간 서버를 거쳐 추적을 어렵게 만드는 패턴

  [07] 상대 경로 Location 해석

  - Location 헤더에 https://... 전체가 아닌 /relative-redirect/1 같은 상대 경로가 옴
  - urljoin으로 현재 URL 기준 절대 경로를 자동 조립
  - 절대 경로든 상대 경로든 동일하게 추적 가능함을 검증

  [08] 스킴 다운그레이드 (HTTPS→HTTP)

  - https://httpbin.org → http://httpbin.org로 리다이렉트
  - scheme_downgrade 신호: 암호화된 HTTPS에서 평문 HTTP로 보안 수준이 떨어짐
  - 중간자 공격(MITM)에 노출될 수 있어 의심 신호로 탐지

  [09] 크로스 오리진 (호스트 변경)

  - httpbin.org → www.google.com으로 완전히 다른 도메인으로 리다이렉트
  - cross_origin 신호: 호스트가 바뀌는 것 자체가 피싱의 대표적 패턴
  - 예: 은행 URL처럼 보이지만 실제로는 피싱 사이트로 보내는 경우

  [10] 존재하지 않는 도메인 (DNS 실패)

  - DNS 조회 자체가 실패하여 HTTP 요청을 보내지 못함 (hop 0개)
  - dns_failure 에러 — 도메인이 삭제되었거나 처음부터 존재하지 않는 URL


# Pull Request 체크리스트

## TODO

- [X] 최종 결과물을 확인했는가?
- [X] 의미 있는 커밋 메시지를 작성했는가?
   