### PR TITLE
[Feat] 페이지 스냅샷 추가

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -194,6 +194,15 @@ class Settings(BaseSettings):
     content_render_settle_ms: int = 500
     content_render_concurrency: int = 2
 
+    # 사용자 표시용 페이지 스냅샷. 파이프라인 응답 SLA 보호를 위해 동기 경로에서는
+    # 기본 1초까지만 기다리고, 지연/실패는 verdict 와 분리해 상태로만 내려준다.
+    page_snapshot_enabled: bool = True
+    page_snapshot_timeout_seconds: float = 1.0
+    page_snapshot_storage_dir: str = "/private/tmp/linclean-page-snapshots"
+    page_snapshot_viewport_width: int = 1365
+    page_snapshot_viewport_height: int = 768
+    page_snapshot_full_page: bool = False
+
     # 콘텐츠 분석 점수
     score_weight_brand_impersonation: int = 50
     score_weight_logo_alt_impersonation: int = 10

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -4,10 +4,13 @@ from app.schemas.db_independent_pipeline import (
     DbIndependentPipelineStages,
     DbIndependentPipelineSuccess,
 )
+from app.schemas.page_snapshot import PageSnapshotResult, PageSnapshotStatus
 
 __all__ = [
     "DbIndependentPipelineFailure",
     "DbIndependentPipelineResult",
     "DbIndependentPipelineStages",
     "DbIndependentPipelineSuccess",
+    "PageSnapshotResult",
+    "PageSnapshotStatus",
 ]

--- a/app/schemas/analysis.py
+++ b/app/schemas/analysis.py
@@ -16,6 +16,7 @@ from app.schemas.db_independent_pipeline import (
 )
 from app.schemas.domain_heuristic import DomainHeuristicResult, DomainHeuristicSignal, RdapInfo
 from app.schemas.normalize import NormalizeResult
+from app.schemas.page_snapshot import PageSnapshotResult, PageSnapshotStatus
 from app.schemas.pipeline import (
     PipelineFailure,
     PipelineResult,
@@ -47,6 +48,8 @@ __all__ = [
     "GSBResult",
     "HopRecord",
     "NormalizeResult",
+    "PageSnapshotResult",
+    "PageSnapshotStatus",
     "PipelineFailure",
     "PipelineResult",
     "PipelineStage",

--- a/app/schemas/db_independent_pipeline.py
+++ b/app/schemas/db_independent_pipeline.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, Field
 from app.schemas.content_analysis import ContentAnalysisResult
 from app.schemas.domain_heuristic import DomainHeuristicResult
 from app.schemas.normalize import NormalizeResult
+from app.schemas.page_snapshot import PageSnapshotResult
 from app.schemas.pipeline import PipelineStage, PipelineTimings, Verdict
 from app.schemas.unchain import UnchainResult
 
@@ -27,6 +28,7 @@ class DbIndependentPipelineSuccess(BaseModel):
     final_url: str
     verdict: Verdict
     score: int = Field(ge=0, le=100)
+    snapshot: PageSnapshotResult | None = None
     timings: PipelineTimings | None = None
     stages: DbIndependentPipelineStages
 

--- a/app/schemas/page_snapshot.py
+++ b/app/schemas/page_snapshot.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+
+class PageSnapshotStatus(StrEnum):
+    AVAILABLE = "available"
+    SKIPPED = "skipped"
+    TIMEOUT = "timeout"
+    FAILED = "failed"
+
+
+class PageSnapshotResult(BaseModel):
+    status: PageSnapshotStatus
+    final_url: str
+    storage_key: str | None = None
+    elapsed_seconds: float | None = Field(default=None, ge=0)
+    error: str | None = None

--- a/app/schemas/pipeline.py
+++ b/app/schemas/pipeline.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field
 from app.schemas.content_analysis import ContentAnalysisResult
 from app.schemas.domain_heuristic import DomainHeuristicResult
 from app.schemas.normalize import NormalizeResult
+from app.schemas.page_snapshot import PageSnapshotResult
 from app.schemas.threat_db import ThreatDbResult
 from app.schemas.unchain import UnchainResult
 
@@ -69,6 +70,7 @@ class PipelineSuccess(BaseModel):
     verdict: Verdict
     score: int = Field(ge=0, le=100)
     summary: str | None = None
+    snapshot: PageSnapshotResult | None = None
     timings: PipelineTimings | None = None
     stages: PipelineStages
 

--- a/app/services/page_snapshot.py
+++ b/app/services/page_snapshot.py
@@ -1,0 +1,130 @@
+"""사용자 표시용 페이지 스냅샷 생성."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from app.core.config import settings
+from app.core.logging import get_logger
+from app.schemas.page_snapshot import PageSnapshotResult, PageSnapshotStatus
+from app.services.content_analyzer.fetch import _pick_user_agent
+from app.services.content_analyzer.render import _target_blocked
+
+logger = get_logger(__name__)
+
+_SAFE_KEY = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+def _elapsed_seconds(started: float) -> float:
+    return round(time.perf_counter() - started, 6)
+
+
+def skipped_page_snapshot(final_url: str, reason: str) -> PageSnapshotResult:
+    return PageSnapshotResult(
+        status=PageSnapshotStatus.SKIPPED,
+        final_url=final_url,
+        error=reason,
+    )
+
+
+def timed_out_page_snapshot(final_url: str, started: float | None = None) -> PageSnapshotResult:
+    return PageSnapshotResult(
+        status=PageSnapshotStatus.TIMEOUT,
+        final_url=final_url,
+        elapsed_seconds=_elapsed_seconds(started) if started is not None else None,
+        error="timeout",
+    )
+
+
+def failed_page_snapshot(
+    final_url: str,
+    *,
+    error: str,
+    started: float | None = None,
+) -> PageSnapshotResult:
+    return PageSnapshotResult(
+        status=PageSnapshotStatus.FAILED,
+        final_url=final_url,
+        elapsed_seconds=_elapsed_seconds(started) if started is not None else None,
+        error=error,
+    )
+
+
+def _storage_path(analysis_id: str) -> tuple[Path, str]:
+    safe_id = _SAFE_KEY.sub("-", analysis_id).strip("-") or "snapshot"
+    storage_dir = Path(settings.page_snapshot_storage_dir)
+    filename = f"{safe_id}.png"
+    return storage_dir / filename, filename
+
+
+def _load_playwright() -> tuple[type[BaseException], Callable[[], Any]]:
+    from playwright.async_api import TimeoutError as PlaywrightTimeoutError
+    from playwright.async_api import async_playwright
+
+    return PlaywrightTimeoutError, async_playwright
+
+
+async def capture_page_snapshot(analysis_id: str, final_url: str) -> PageSnapshotResult:
+    """Playwright 로 최종 URL 첫 화면 PNG 를 저장한다.
+
+    보안 차단은 콘텐츠 렌더링과 같은 대상 host 검사를 재사용한다. Playwright 가 없거나
+    브라우저 실행이 실패하면 파이프라인을 깨지 않고 failed 상태를 반환한다.
+    """
+    started = time.perf_counter()
+
+    if not settings.page_snapshot_enabled:
+        return skipped_page_snapshot(final_url, "snapshot_disabled")
+
+    if await _target_blocked(final_url):
+        logger.info("page_snapshot.blocked_host", url=final_url)
+        return failed_page_snapshot(final_url, error="blocked_host", started=started)
+
+    try:
+        playwright_timeout_error, async_playwright = _load_playwright()
+    except ImportError:
+        return failed_page_snapshot(final_url, error="playwright_unavailable", started=started)
+
+    path, storage_key = _storage_path(analysis_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    timeout_ms = int(settings.page_snapshot_timeout_seconds * 1000)
+
+    try:
+        async with async_playwright() as p:
+            browser = await p.chromium.launch(headless=True)
+            try:
+                page = await browser.new_page(
+                    user_agent=_pick_user_agent(),
+                    locale="ko-KR",
+                    viewport={
+                        "width": settings.page_snapshot_viewport_width,
+                        "height": settings.page_snapshot_viewport_height,
+                    },
+                )
+                await page.goto(final_url, wait_until="domcontentloaded", timeout=timeout_ms)
+                await page.screenshot(path=str(path), full_page=settings.page_snapshot_full_page)
+            finally:
+                await browser.close()
+    except playwright_timeout_error:
+        return timed_out_page_snapshot(final_url, started)
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        logger.warning(
+            "page_snapshot.failed",
+            url=final_url,
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+        return failed_page_snapshot(final_url, error="snapshot_failed", started=started)
+
+    return PageSnapshotResult(
+        status=PageSnapshotStatus.AVAILABLE,
+        final_url=final_url,
+        storage_key=storage_key,
+        elapsed_seconds=_elapsed_seconds(started),
+    )

--- a/app/services/pipeline.py
+++ b/app/services/pipeline.py
@@ -21,6 +21,7 @@ from app.schemas.domain_heuristic import (
     DomainHeuristicSkippedReason,
 )
 from app.schemas.normalize import NormalizeResult
+from app.schemas.page_snapshot import PageSnapshotResult
 from app.schemas.pipeline import (
     PipelineFailure,
     PipelineStage,
@@ -36,6 +37,12 @@ from app.services.analysis_summary import build_analysis_summary
 from app.services.content_analyzer import analyze_content, skipped_already_danger
 from app.services.domain_heuristic import check_domain_heuristic
 from app.services.normalizer import normalize_url
+from app.services.page_snapshot import (
+    capture_page_snapshot,
+    failed_page_snapshot,
+    skipped_page_snapshot,
+    timed_out_page_snapshot,
+)
 from app.services.page_unavailability import (
     PAGE_UNAVAILABLE_CODE,
     content_page_unavailable,
@@ -213,6 +220,40 @@ async def _stage_content_analysis(
     return result
 
 
+async def _capture_snapshot_for_pipeline(
+    log: structlog.stdlib.BoundLogger,
+    analysis_id: str,
+    final_url: str,
+) -> PageSnapshotResult:
+    started = time.perf_counter()
+    try:
+        result = await asyncio.wait_for(
+            capture_page_snapshot(analysis_id, final_url),
+            timeout=settings.page_snapshot_timeout_seconds,
+        )
+    except TimeoutError:
+        result = timed_out_page_snapshot(final_url, started)
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        log.warning(
+            "pipeline.page_snapshot.failed",
+            final_url=final_url,
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+        result = failed_page_snapshot(final_url, error="snapshot_failed", started=started)
+
+    log.info(
+        "pipeline.page_snapshot.done",
+        status=result.status.value,
+        storage_key=result.storage_key,
+        elapsed_seconds=result.elapsed_seconds,
+        error=result.error,
+    )
+    return result
+
+
 def _preceding_score(threat: ThreatDbResult, heuristic: DomainHeuristicResult) -> int:
     """2~3단계 누적 점수. 4단계 건너뛸지 판단하는 기준."""
     score = heuristic.score
@@ -307,6 +348,7 @@ def _pipeline_success(
     threat: ThreatDbResult,
     heuristic: DomainHeuristicResult,
     content: ContentAnalysisResult,
+    snapshot: PageSnapshotResult | None = None,
 ) -> PipelineSuccess:
     return PipelineSuccess(
         analysis_id=analysis_id,
@@ -320,6 +362,7 @@ def _pipeline_success(
             heuristic=heuristic,
             content=content,
         ),
+        snapshot=snapshot,
         timings=_build_timings(started, stage_timings),
         stages=PipelineStages(
             normalize=normalize,
@@ -499,6 +542,7 @@ async def run_pipeline(
         score = _total_score(threat, heuristic, content)
         if threat.is_malicious or score >= settings.score_caution_threshold:
             verdict = _decide_verdict(score, threat)
+            page_unavailable_snapshot = skipped_page_snapshot(unchain.final_url, "page_unavailable")
             return _pipeline_success(
                 analysis_id=analysis_id,
                 original_url=original_url,
@@ -512,6 +556,7 @@ async def run_pipeline(
                 threat=threat,
                 heuristic=heuristic,
                 content=content,
+                snapshot=page_unavailable_snapshot,
             )
         return _page_unavailable_failure(
             analysis_id=analysis_id,
@@ -557,6 +602,8 @@ async def run_pipeline(
         short_circuited = False
 
     heuristic = _augment_heuristic_with_redirect_signals(heuristic, unchain)
+    snapshot: PageSnapshotResult | None = None
+    snapshot_task: asyncio.Task[PageSnapshotResult] | None = None
 
     if short_circuited:
         log.info(
@@ -568,6 +615,7 @@ async def run_pipeline(
         stage_started = time.perf_counter()
         content = skipped_already_danger(unchain.final_url)
         _set_stage_timing(stage_timings, PipelineStage.CONTENT_ANALYSIS, stage_started)
+        snapshot = skipped_page_snapshot(unchain.final_url, "skipped_already_danger")
     else:
         # known malicious 는 verdict 가 이미 외부 DB 로 확정됐으므로 페이지를 받아보지 않는다.
         # 휴리스틱 danger 는 페이지가 존재하지 않을 수 있으므로 content fetch 로 가용성을 확인한다.
@@ -581,8 +629,12 @@ async def run_pipeline(
             stage_started = time.perf_counter()
             content = skipped_already_danger(unchain.final_url)
             _set_stage_timing(stage_timings, PipelineStage.CONTENT_ANALYSIS, stage_started)
+            snapshot = skipped_page_snapshot(unchain.final_url, "skipped_already_danger")
         else:
             upstream = _collect_upstream_signals(threat, heuristic)
+            snapshot_task = asyncio.create_task(
+                _capture_snapshot_for_pipeline(log, analysis_id, unchain.final_url)
+            )
             try:
                 content = await deadline.run(
                     PipelineStage.CONTENT_ANALYSIS.value,
@@ -610,6 +662,8 @@ async def run_pipeline(
                 )
                 content = timed_out_content_result(unchain.final_url)
 
+            snapshot = await snapshot_task
+
     if unavailable := content_page_unavailable(content):
         message, status_code = unavailable
         log.info(
@@ -635,6 +689,7 @@ async def run_pipeline(
                 threat=threat,
                 heuristic=heuristic,
                 content=content,
+                snapshot=snapshot,
             )
         return _page_unavailable_failure(
             analysis_id=analysis_id,
@@ -668,4 +723,5 @@ async def run_pipeline(
         threat=threat,
         heuristic=heuristic,
         content=content,
+        snapshot=snapshot,
     )

--- a/tests/services/test_page_snapshot.py
+++ b/tests/services/test_page_snapshot.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from app.core.config import settings
+from app.schemas.page_snapshot import PageSnapshotStatus
+from app.services.page_snapshot import capture_page_snapshot, skipped_page_snapshot
+
+
+def test_skipped_page_snapshot_marks_reason() -> None:
+    result = skipped_page_snapshot("https://example.com/", "skipped_already_danger")
+
+    assert result.status == PageSnapshotStatus.SKIPPED
+    assert result.final_url == "https://example.com/"
+    assert result.error == "skipped_already_danger"
+    assert result.storage_key is None
+
+
+@pytest.mark.asyncio
+async def test_capture_page_snapshot_returns_failed_when_target_is_blocked() -> None:
+    with patch("app.services.page_snapshot._target_blocked", new_callable=AsyncMock) as blocked:
+        blocked.return_value = True
+
+        result = await capture_page_snapshot("aid-blocked", "http://127.0.0.1/")
+
+    assert result.status == PageSnapshotStatus.FAILED
+    assert result.error == "blocked_host"
+    assert result.elapsed_seconds is not None
+
+
+@pytest.mark.asyncio
+async def test_capture_page_snapshot_sanitizes_storage_key(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "page_snapshot_storage_dir", str(tmp_path))
+
+    with (
+        patch("app.services.page_snapshot._target_blocked", new_callable=AsyncMock) as blocked,
+        patch("app.services.page_snapshot._load_playwright") as load_playwright,
+    ):
+        blocked.return_value = False
+        page = AsyncMock()
+        browser = AsyncMock()
+        browser.new_page.return_value = page
+        chromium = AsyncMock()
+        chromium.launch.return_value = browser
+        playwright_context = MagicMock()
+        playwright_context.__aenter__ = AsyncMock(
+            return_value=MagicMock(chromium=chromium)
+        )
+        playwright_context.__aexit__ = AsyncMock(return_value=None)
+        async_playwright = MagicMock(return_value=playwright_context)
+        load_playwright.return_value = (TimeoutError, async_playwright)
+
+        result = await capture_page_snapshot("aid/#45 snapshot", "https://example.com/")
+
+    assert result.status == PageSnapshotStatus.AVAILABLE
+    assert result.storage_key == "aid-45-snapshot.png"
+    page.screenshot.assert_awaited_once_with(
+        path=str(tmp_path / "aid-45-snapshot.png"),
+        full_page=settings.page_snapshot_full_page,
+    )

--- a/tests/services/test_pipeline.py
+++ b/tests/services/test_pipeline.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import time
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
@@ -12,6 +13,7 @@ from app.core.config import settings
 from app.schemas.content_analysis import ContentAnalysisResult, ContentSignal
 from app.schemas.domain_heuristic import DomainHeuristicResult, DomainHeuristicSignal
 from app.schemas.normalize import NormalizeResult
+from app.schemas.page_snapshot import PageSnapshotResult, PageSnapshotStatus
 from app.schemas.pipeline import PipelineFailure, PipelineStage, PipelineSuccess, Verdict
 from app.schemas.threat_db import GSBMatch, GSBResult, ThreatDbResult, URLhausResult
 from app.schemas.unchain import HopRecord, UnchainResult
@@ -145,6 +147,150 @@ async def test_run_pipeline_includes_domain_heuristic_stage(async_session: Async
     assert args == (final_url,)
     # _make_heuristic 가 HOSTING_PLATFORM 시그널을 가지므로 그대로 전달돼야 한다
     assert await _resolve_upstream(kwargs["upstream_signals"]) == ("HOSTING_PLATFORM",)
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_no_ai_passes_flag_to_content_analysis(
+    async_session: AsyncSession,
+) -> None:
+    final_url = "https://example.com/"
+
+    with (
+        patch("app.services.pipeline.normalize_url") as mock_norm,
+        patch("app.services.pipeline.unchain_url", new_callable=AsyncMock) as mock_unchain,
+        patch("app.services.pipeline.check_threat_db", new_callable=AsyncMock) as mock_threat,
+        patch(
+            "app.services.pipeline.check_domain_heuristic", new_callable=AsyncMock
+        ) as mock_heuristic,
+        patch("app.services.pipeline.analyze_content", new_callable=AsyncMock) as mock_content,
+    ):
+        mock_norm.return_value = NormalizeResult(original_url=final_url, normalized_url=final_url)
+        mock_unchain.return_value = _make_unchain(final_url)
+        mock_threat.return_value = _make_threat(final_url)
+        mock_heuristic.return_value = _make_heuristic("example.com")
+        mock_content.return_value = _make_content(final_url)
+
+        result = await run_pipeline("aid-no-ai", final_url, async_session, use_ai=False)
+
+    assert isinstance(result, PipelineSuccess)
+    mock_content.assert_awaited_once()
+    assert mock_content.await_args.kwargs["use_ai"] is False
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_includes_available_page_snapshot(
+    async_session: AsyncSession,
+) -> None:
+    final_url = "https://example.com/"
+
+    with (
+        patch("app.services.pipeline.normalize_url") as mock_norm,
+        patch("app.services.pipeline.unchain_url", new_callable=AsyncMock) as mock_unchain,
+        patch("app.services.pipeline.check_threat_db", new_callable=AsyncMock) as mock_threat,
+        patch(
+            "app.services.pipeline.check_domain_heuristic", new_callable=AsyncMock
+        ) as mock_heuristic,
+        patch("app.services.pipeline.analyze_content", new_callable=AsyncMock) as mock_content,
+        patch(
+            "app.services.pipeline.capture_page_snapshot", new_callable=AsyncMock
+        ) as mock_snapshot,
+    ):
+        mock_norm.return_value = NormalizeResult(original_url=final_url, normalized_url=final_url)
+        mock_unchain.return_value = _make_unchain(final_url)
+        mock_threat.return_value = _make_threat(final_url)
+        mock_heuristic.return_value = _make_heuristic("example.com")
+        mock_content.return_value = _make_content(final_url)
+        mock_snapshot.return_value = PageSnapshotResult(
+            status=PageSnapshotStatus.AVAILABLE,
+            final_url=final_url,
+            storage_key="page-snapshots/aid-snapshot.png",
+            elapsed_seconds=0.25,
+        )
+
+        result = await run_pipeline("aid-snapshot", final_url, async_session)
+
+    assert isinstance(result, PipelineSuccess)
+    assert result.snapshot is not None
+    assert result.snapshot.status == PageSnapshotStatus.AVAILABLE
+    assert result.snapshot.storage_key == "page-snapshots/aid-snapshot.png"
+    assert result.snapshot.elapsed_seconds == 0.25
+    mock_snapshot.assert_awaited_once_with("aid-snapshot", final_url)
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_skips_page_snapshot_when_threat_db_short_circuits(
+    async_session: AsyncSession,
+) -> None:
+    final_url = "https://evil.test/"
+
+    with (
+        patch("app.services.pipeline.normalize_url") as mock_norm,
+        patch("app.services.pipeline.unchain_url", new_callable=AsyncMock) as mock_unchain,
+        patch("app.services.pipeline.check_threat_db", new_callable=AsyncMock) as mock_threat,
+        patch(
+            "app.services.pipeline.check_domain_heuristic", new_callable=AsyncMock
+        ) as mock_heuristic,
+        patch("app.services.pipeline.analyze_content", new_callable=AsyncMock),
+        patch(
+            "app.services.pipeline.capture_page_snapshot", new_callable=AsyncMock
+        ) as mock_snapshot,
+    ):
+        mock_norm.return_value = NormalizeResult(original_url=final_url, normalized_url=final_url)
+        mock_unchain.return_value = _make_unchain(final_url)
+        mock_threat.return_value = _malicious_threat(final_url)
+        mock_heuristic.return_value = _heuristic_with_score(20)
+
+        result = await run_pipeline("aid-skip-snapshot", final_url, async_session)
+
+    assert isinstance(result, PipelineSuccess)
+    assert result.snapshot is not None
+    assert result.snapshot.status == PageSnapshotStatus.SKIPPED
+    assert result.snapshot.error == "skipped_already_danger"
+    mock_snapshot.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_times_out_slow_page_snapshot_without_delaying_verdict(
+    async_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    final_url = "https://slow-snapshot.test/"
+    monkeypatch.setattr(settings, "page_snapshot_timeout_seconds", 0.01)
+
+    async def slow_snapshot(_analysis_id: str, _url: str) -> PageSnapshotResult:
+        await asyncio.sleep(5.0)
+        return PageSnapshotResult(
+            status=PageSnapshotStatus.AVAILABLE,
+            final_url=final_url,
+            storage_key="page-snapshots/too-late.png",
+        )
+
+    with (
+        patch("app.services.pipeline.normalize_url") as mock_norm,
+        patch("app.services.pipeline.unchain_url", new_callable=AsyncMock) as mock_unchain,
+        patch("app.services.pipeline.check_threat_db", new_callable=AsyncMock) as mock_threat,
+        patch(
+            "app.services.pipeline.check_domain_heuristic", new_callable=AsyncMock
+        ) as mock_heuristic,
+        patch("app.services.pipeline.analyze_content", new_callable=AsyncMock) as mock_content,
+        patch("app.services.pipeline.capture_page_snapshot", side_effect=slow_snapshot),
+    ):
+        mock_norm.return_value = NormalizeResult(original_url=final_url, normalized_url=final_url)
+        mock_unchain.return_value = _make_unchain(final_url)
+        mock_threat.return_value = _make_threat(final_url)
+        mock_heuristic.return_value = _make_heuristic("slow-snapshot.test")
+        mock_content.return_value = _make_content(final_url)
+
+        started = time.perf_counter()
+        result = await run_pipeline("aid-slow-snapshot", final_url, async_session)
+        elapsed = time.perf_counter() - started
+
+    assert isinstance(result, PipelineSuccess)
+    assert result.verdict == Verdict.SAFE
+    assert result.snapshot is not None
+    assert result.snapshot.status == PageSnapshotStatus.TIMEOUT
+    assert result.snapshot.elapsed_seconds is not None
+    assert elapsed < 1.0
 
 
 @pytest.mark.asyncio
@@ -676,9 +822,7 @@ async def test_short_circuit_uses_placeholder_even_when_heuristic_finishes_first
         patch("app.services.pipeline.check_domain_heuristic", side_effect=fast_heuristic),
         patch("app.services.pipeline.analyze_content", new_callable=AsyncMock),
     ):
-        mock_norm.return_value = NormalizeResult(
-            original_url=final_url, normalized_url=final_url
-        )
+        mock_norm.return_value = NormalizeResult(original_url=final_url, normalized_url=final_url)
         mock_unchain.return_value = _make_unchain(final_url)
 
         result = await run_pipeline("aid-race", final_url, async_session)


### PR DESCRIPTION
 # 요약

  링크 검사 결과에서 사용자가 최종 URL의 페이지 화면을 확인할 수 있도록 페이지 스냅샷 생성 기능을 추가했습니다. 스냅샷 이미지를 API 응답에 직접 포함하지 않고, 서버 로컬 저장소에 PNG로 저장한 뒤 응답에는 스냅샷 상태와 `storage_key`를 내려주는 방식입니다. (임시)

  주요 변경 사항:

  - `PageSnapshotResult`, `PageSnapshotStatus` 스키마 추가
  - `PipelineSuccess.snapshot` 응답 필드 추가
  - Playwright 기반 페이지 스냅샷 생성 서비스 추가
  - 정상 검사 경로에서 콘텐츠 분석과 스냅샷 생성을 병렬 실행
  - threat DB 매치 등으로 위험 판정이 이미 확정된 경우 스냅샷 생성 스킵
  - 스냅샷 실패/타임아웃이 verdict, score, summary에 영향을 주지 않도록 분리
  - 기본 스냅샷 대기 시간을 1초로 제한해 파이프라인 응답 지연을 방지
  - 스냅샷 상태를 `available`, `skipped`, `timeout`, `failed`로 구분

  응답 :

  ```json
  {
    "status": "success",
    "verdict": "safe",
    "score": 0,
    "summary": "현재 분석 기준에서 뚜렷한 위험 신호가 확인되지 않았습니다.",
    "snapshot": {
      "status": "available",
      "final_url": "https://example.com/",
      "storage_key": "aid-snapshot.png",
      "elapsed_seconds": 0.83,
      "error": null
    }
  }
```

  ## 이미지 전달 방식 검토

  ### 1. S3/R2/GCS 등 객체 스토리지 사용

  흐름:

  1. FastAPI가 최종 URL 페이지 스냅샷을 PNG로 생성
  2. PNG를 S3 같은 객체 스토리지에 업로드
  3. 응답에는 snapshot_url 또는 storage_key 반환
  4. 프론트엔드는 해당 URL로 이미지를 표시
  5. 일정 시간이 지나면 lifecycle rule 또는 백엔드 cleanup job으로 삭제

  예시 응답:
  ```json
  {
    "snapshot": {
      "status": "available",
      "final_url": "https://example.com/",
      "storage_key": "snapshots/analysis-id.png",
      "snapshot_url": "https://cdn.example.com/snapshots/analysis-id.png",
      "elapsed_seconds": 0.83
    }
  }
  ```

  장점:

  - API 응답 크기가 작음
  - 프론트에서 일반 이미지처럼 로드 가능
  - CDN 캐싱 가능
  - 만료/삭제 정책 적용 쉬움
  - 다중 서버 환경에서도 안정적
  - 이미지 재조회가 쉬움

  삭제 방식 예시:

  - S3 lifecycle rule로 snapshots/ prefix 파일을 1일 후 자동 삭제
  - 또는 분석 결과 조회 가능 시간이 짧다면 10분~1시간 TTL 적용
  - 민감 페이지 가능성을 고려하면 public bucket보다는 presigned URL 방식 권장

  운영 방식:

  FastAPI -> S3 private bucket 업로드 -> presigned URL 발급 -> 프론트 표시 -> TTL 후 만료/삭제

  ### 2. base64 inline 응답

  이미지를 API 응답 JSON 안에 직접 넣는 방식입니다.

  예시:
  ```json
  {
    "snapshot": {
      "status": "available",
      "mime_type": "image/png",
      "base64": "iVBORw0KGgoAAAANSUhEUg...",
      "elapsed_seconds": 0.83
    }
  }
  ```

  장점:

  - 별도 저장소가 필요 없음
  - 프론트가 즉시 data:image/png;base64,...로 표시 가능
  - MVP나 내부 테스트에는 단순함

  단점:

  - PNG 원본보다 약 33% 커짐
  - API 응답 크기가 커짐
  - callback, 로그, APM, gateway body size 제한에 걸릴 수 있음
  - 캐싱/재조회/삭제 개념이 애매함
  - 여러 사용자가 동시에 요청하면 네트워크 비용이 커짐

  현실적인 사용 조건:

  - 스냅샷이 1장이고 수백 KB 수준
  - 내부 테스트 또는 MVP
  - 응답 크기 제한을 명확히 둠

  예시 제한:

  page_snapshot_inline_max_bytes = 500_000

  ### 3. FastAPI 로컬 디스크 + 정적 파일 서빙

  흐름:

  1. FastAPI 서버 로컬 디스크에 PNG 저장
  2. /static/snapshots/{id}.png 같은 URL로 제공
  3. 응답에는 해당 경로 반환

  장점:

  - 구현이 단순함
  - 개발/스테이징 테스트에 적합
  - S3 없이 바로 확인 가능

  단점:

  - 운영 다중 인스턴스 환경에서 문제가 생김
  - 서버 재시작/배포 시 파일 유지가 불안정함
  - 디스크 cleanup 필요
  - CDN/접근 제어/만료 처리가 번거로움

  ## 성능 테스트 결과

  실제 정상 URL 10개를 대상으로 스냅샷 생성 테스트를 수행했습니다.

  테스트 URL:

  - https://www.google.com/
<img width="1470" height="923" alt="스크린샷 2026-07-07 오후 5 34 36" src="https://github.com/user-attachments/assets/450d1632-4c77-4449-b842-47b1787a1f6f" />

- https://www.youtube.com/
- https://www.wikipedia.org/
- https://www.apple.com/
- https://www.microsoft.com/
- https://github.com/
- https://www.python.org/
- https://fastapi.tiangolo.com/
- https://www.postgresql.org/
- https://www.mozilla.org/

  결과:

  - 총 10개
  - 성공 10개
  - 실패 0개
  - 타임아웃 0개
  - 평균 생성 시간: 약 1.94초
  - median: 약 1.99초

  테스트 산출물은 로컬 확인용으로 생성했으며 PR 커밋에는 포함하지 않았습니다.

  ## 테스트

  실행한 검증:

  ruff check app/services/page_snapshot.py app/services/pipeline.py app/schemas/page_snapshot.py app/schemas/pipeline.py app/schemas/db_independent_pipeline.py tests/
  services/test_page_snapshot.py tests/services/test_pipeline.py

  pytest tests/services/test_pipeline.py tests/services/test_page_snapshot.py tests/api/test_analyze_db_independent.py tests/services/test_analysis_callback.py

  결과:

  - ruff 통과
  - 관련 테스트 39개 통과

  참고:

  전체 pytest 실행 시 450개 통과, 5개 실패가 있었으나 실패는 기존 작업트리에 남아 있는 OpenAIProvider 테스트 기대값 변경과 관련된 것으로, 이번 페이지 스냅샷 커밋에는 포함하지 않았습니다.

  # 연관 이슈 및 Close 할 이슈

  close #45

  # Pull Request 체크리스트

  ## TODO

  - [x] 최종 결과물을 확인했는가?
  - [x] 의미 있는 커밋 메시지를 작성했는가?

